### PR TITLE
Check if GNU sed  is used on macOS instead of assuming BSD sed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,30 +351,55 @@ if (NOT SED_TOOL)
 endif (NOT SED_TOOL)
 
 
-
 if(APPLE)
+
+# by default assume BSD sed command is used on macOS
+set(USING_MACOS_SED TRUE)
+set(SED_TOOL_CMD "${SED_TOOL} -i \"\"") # mac (BSD) sed
+
+# detect version of SED_TOOL versionL
+message(STATUS "detecting sed version...")
+execute_process (
+    COMMAND ${SED_TOOL} --version
+    WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
+    OUTPUT_VARIABLE SED_TOOL_VERSION
+    )
+message( STATUS "${SED_TOOL_VERSION}" )
+
+if (SED_TOOL_VERSION MATCHES ".*GNU sed.*")
+    message(STATUS "using GNU sed...")
+    set(SED_TOOL_CMD "${SED_TOOL} -i") # GNU sed
+    set(USING_MACOS_SED FALSE)
+endif()
+
+message(STATUS "sed command [${SED_TOOL_CMD}]")
+
 execute_process (
      COMMAND cp PrecisionPreprocessing.sh PrecisionPreprocessing_mac.sh
      WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
 )
+
+if (USING_MACOS_SED)
 execute_process (
-     COMMAND ${SED_TOOL} -i "" -e "s/sed -i/sed -i \"\"/g" PrecisionPreprocessing_mac.sh
+     COMMAND ${SED_TOOL_CMD} -e "s/sed -i/sed -i \"\"/g" PrecisionPreprocessing_mac.sh
+     WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
+)
+endif()
+
+execute_process (
+     COMMAND ${SED_TOOL_CMD} -e "s/eval//g" PrecisionPreprocessing_mac.sh
      WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
 )
 execute_process (
-     COMMAND ${SED_TOOL} -i "" -e "s/eval//g" PrecisionPreprocessing_mac.sh
+     COMMAND ${SED_TOOL_CMD} -e "/\r\"/d" PrecisionPreprocessing_mac.sh
      WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
 )
 execute_process (
-     COMMAND ${SED_TOOL} -i "" -e "/\r\"/d" PrecisionPreprocessing_mac.sh
+     COMMAND ${SED_TOOL_CMD} -e "s/lb=.*/lb=\"[[:<:]]\"/g" PrecisionPreprocessing_mac.sh
      WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
 )
 execute_process (
-     COMMAND ${SED_TOOL} -i "" -e "s/lb=.*/lb=\"[[:<:]]\"/g" PrecisionPreprocessing_mac.sh
-     WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
-)
-execute_process (
-     COMMAND ${SED_TOOL} -i "" -e "s/rb=.*/rb=\"[[:>:]]\"/g" PrecisionPreprocessing_mac.sh
+     COMMAND ${SED_TOOL_CMD} -e "s/rb=.*/rb=\"[[:>:]]\"/g" PrecisionPreprocessing_mac.sh
      WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
 )
 execute_process (


### PR DESCRIPTION
The build system was assuming that BSD sed is used on
macOS. However, that may not be always the case since
GNU sed can be installed instead, e.g., via homebrew,
macports, or other package manager. Unfortunately,
BSD sed and GNU sed have some subtle differences and
take different arguments. This commit attempts to detect
if GNU sed is used and changes the command line arguments
accordingly.