### PR TITLE
Enable builds without OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,9 @@ set(VERSION_MINOR "1")
 set(VERSION_BugFix "1")
 set(PROJECT_VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BugFix})
 
-
 # Set up options
 option(enable_doc       "Build doxygen documentation" OFF)
-
+option(enable_openmp    "Build with OpenMP support" ON)
 
 ######################################################################
 #
@@ -45,9 +44,7 @@ ENDFOREACH()
 # Usual initialization stuff
 #
 ######################################################################
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)    ## ????
-set(CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
-#---- For shared library
+SET(CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
 
 # use, i.e. don't skip the full RPATH for the build tree
 SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
@@ -62,77 +59,76 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 # add the automatically determined parts of the RPATH
 # which point to directories outside the build tree to the install RPATH
 SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-#----
 
-if (BUILD_SHARED_LIBS)
+if(BUILD_SHARED_LIBS)
   message("-- ButterflyPACK will be built as a shared library.")
 else()
   message("-- ButterflyPACK will be built as a static library.")
 endif()
 
-enable_language (C)
-enable_language (CXX)
+enable_language(C)
+enable_language(CXX)
 set(CMAKE_CXX_STANDARD 11)
-if (XSDK_ENABLE_Fortran)
-  enable_language (Fortran)
+if(XSDK_ENABLE_Fortran)
+  enable_language(Fortran)
   set(NOFORTRAN FALSE)
 endif()
 set(ButterflyPACK_VERSION "${PROJECT_VERSION}")
 set(ButterflyPACK_REV "${PROJECT_REV}")
 
-if (NOT CMAKE_INSTALL_PREFIX)
+if(NOT CMAKE_INSTALL_PREFIX)
   set(CMAKE_INSTALL_PREFIX /usr/local)
 endif()
-
 
 ######################################################################
 #
 # Add compiler-specific compiler flags
 #
 ######################################################################
-
-# set(CMAKE_Fortran_FLAGS "-cpp ${CMAKE_Fortran_FLAGS}")
 include(CheckFortranCompilerFlag)
+include(CheckCXXCompilerFlag)
+
 check_fortran_compiler_flag("-ffree-line-length-none" COMPILER_GNU)
-if (COMPILER_GNU)
-set(CMAKE_Fortran_FLAGS "-cpp -fno-range-check -ffree-line-length-none -ffixed-line-length-none -fimplicit-none -lpthread ${CMAKE_Fortran_FLAGS}")
-check_fortran_compiler_flag("-fallow-argument-mismatch" GNU10)
-if (GNU10)
-set(CMAKE_Fortran_FLAGS "-fallow-argument-mismatch ${CMAKE_Fortran_FLAGS}")
+if(COMPILER_GNU)
+  set(CMAKE_Fortran_FLAGS "-cpp -fno-range-check -ffree-line-length-none -ffixed-line-length-none -fimplicit-none -lpthread ${CMAKE_Fortran_FLAGS}")
+  check_fortran_compiler_flag("-fallow-argument-mismatch" GNU10)
+  if(GNU10)
+  set(CMAKE_Fortran_FLAGS "-fallow-argument-mismatch ${CMAKE_Fortran_FLAGS}")
+  endif()
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(CMAKE_Fortran_FLAGS "-fno-range-check -fbacktrace -fbounds-check -Wconversion ${CMAKE_Fortran_FLAGS}")
+  endif()
 endif()
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-set(CMAKE_Fortran_FLAGS "-fno-range-check -fbacktrace -fbounds-check -Wconversion ${CMAKE_Fortran_FLAGS}")
-endif()
-endif()
+
 check_fortran_compiler_flag("-no-prec-div" COMPILER_Intel)
-if (COMPILER_Intel)
-set(CMAKE_Fortran_FLAGS "-cpp -DIntel ${CMAKE_Fortran_FLAGS}")
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-set(CMAKE_Fortran_FLAGS "-traceback -debug full -check bounds ${CMAKE_Fortran_FLAGS}")
-endif()
+if(COMPILER_Intel)
+  set(CMAKE_Fortran_FLAGS "-cpp -DIntel ${CMAKE_Fortran_FLAGS}")
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CMAKE_Fortran_FLAGS "-traceback -debug full -check bounds ${CMAKE_Fortran_FLAGS}")
+  endif()
 endif()
 
 check_fortran_compiler_flag("-Mextend" COMPILER_PGI)
-if (COMPILER_PGI)
-set(CMAKE_Fortran_FLAGS "-cpp -Mextend -DPGI ${CMAKE_Fortran_FLAGS}")
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-set(CMAKE_Fortran_FLAGS "-O0 -g -Mbounds -Mdepchk -traceback ${CMAKE_Fortran_FLAGS}")
-endif()
+if(COMPILER_PGI)
+  set(CMAKE_Fortran_FLAGS "-cpp -Mextend -DPGI ${CMAKE_Fortran_FLAGS}")
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CMAKE_Fortran_FLAGS "-O0 -g -Mbounds -Mdepchk -traceback ${CMAKE_Fortran_FLAGS}")
+  endif()
 endif()
 
 check_fortran_compiler_flag("-N 1023" COMPILER_CRAY)
-if (COMPILER_CRAY OR CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
-set(CMAKE_Fortran_FLAGS "-e Z -h omp -N 1023 -DCRAY ${CMAKE_Fortran_FLAGS}")
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-set(CMAKE_Fortran_FLAGS "-O0 -g -e D ${CMAKE_Fortran_FLAGS}")
-endif()
+if(COMPILER_CRAY OR CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")
+  set(CMAKE_Fortran_FLAGS "-e Z -h omp -N 1023 -DCRAY ${CMAKE_Fortran_FLAGS}")
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CMAKE_Fortran_FLAGS "-O0 -g -e D ${CMAKE_Fortran_FLAGS}")
+  endif()
 endif()
 
-
-if (COMPILER_PGI OR COMPILER_CRAY OR CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")  # PGI and Cray taskloop seems buggy
-else()
-#Test OPENMP TASKLOOP
-check_fortran_source_compiles(
+# Test OPENMP TASKLOOP
+if(enable_openmp)
+  if(COMPILER_PGI OR COMPILER_CRAY OR CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")  # PGI and Cray taskloop seems buggy
+  else()
+    check_fortran_source_compiles(
 "PROGRAM TEST
 integer i
 !$omp parallel
@@ -145,163 +141,151 @@ enddo
 !$omp end single
 !$omp end parallel
 END PROGRAM TEST" BUTTERFLYPACK_USE_TASKLOOP SRC_EXT F90)
-if(BUTTERFLYPACK_USE_TASKLOOP )
-	set(CMAKE_Fortran_FLAGS "-DHAVE_TASKLOOP ${CMAKE_Fortran_FLAGS}")
-	message("-- Using OpenMP taskloop")
-endif()
+    if(BUTTERFLYPACK_USE_TASKLOOP)
+      set(CMAKE_Fortran_FLAGS "-DHAVE_TASKLOOP ${CMAKE_Fortran_FLAGS}")
+      message("-- Using OpenMP taskloop")
+    endif()
+  endif()
 endif()
 
 set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
-include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-qopt-matmul" qoptmatmul)
-if (qoptmatmul)
-set(CMAKE_CXX_FLAGS  "-qopt-matmul ${CMAKE_CXX_FLAGS}")
+if(qoptmatmul)
+  set(CMAKE_CXX_FLAGS  "-qopt-matmul ${CMAKE_CXX_FLAGS}")
 endif()
-
-
 
 ######################################################################
 #
 # Find packages
 #
 ######################################################################
-
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
   "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
-
-#---------------------- Additional Fortran linker library ---------
+#-------- Additional Fortran linker library --------
 #if(APPLE)
 #else()
-SET(_fortran_libs ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES})
-FOREACH(_lib ${_fortran_libs})
+set(_fortran_libs ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES})
+foreach(_lib ${_fortran_libs})
   # FIND_SYSTEM_LIBRARY(${_lib}_LIBRARY NAMES ${_lib})
   set(EXTRA_LIB "-l${_lib} ${EXTRA_LIB}")
-ENDFOREACH()
+endforeach()
 #endif()
 
-
 #--------------------- OpenMP ---------------------
-find_package(OpenMP)
-## include(FindOpenMP)  # Strumpack uses this
-
-if(OPENMP_FORTRAN_FOUND)
-  set(CMAKE_Fortran_FLAGS "${OpenMP_Fortran_FLAGS} ${CMAKE_Fortran_FLAGS}")
-  set(OpenMP_Fortran_FLAGS_EXPORT "${OpenMP_Fortran_FLAGS}")
-  set(CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES "${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES} ${OpenMP_Fortran_FLAGS}")
+if(enable_openmp)
+  find_package(OpenMP)
+  if(OPENMP_FORTRAN_FOUND)
+    set(CMAKE_Fortran_FLAGS "-DHAVE_OPENMP ${OpenMP_Fortran_FLAGS} ${CMAKE_Fortran_FLAGS}")
+    set(OpenMP_Fortran_FLAGS_EXPORT "${OpenMP_Fortran_FLAGS}")
+    set(CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES "${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES} ${OpenMP_Fortran_FLAGS}")
+  endif()
+  if(OPENMP_CXX_FOUND)
+    set(CMAKE_CXX_FLAGS "-DHAVE_OPENMP ${OpenMP_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
+    set(OpenMP_CXX_FLAGS_EXPORT "${OpenMP_CXX_FLAGS}")
+    set(CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES} ${OpenMP_CXX_FLAGS}")
+  endif()
 endif()
 
-if(OPENMP_CXX_FOUND)
-  set(CMAKE_CXX_FLAGS "${OpenMP_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
-  set(OpenMP_CXX_FLAGS_EXPORT "${OpenMP_CXX_FLAGS}")
-  set(CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES} ${OpenMP_CXX_FLAGS}")
-endif()
-
-
- # #--------------------- BLAS ---------------------
+#--------------------- BLAS ---------------------
 if(TPL_BLAS_LIBRARIES)
-	set(BLAS_FOUND TRUE)
+  set(BLAS_FOUND TRUE)
 else()
-	find_package(BLAS)
-	if(BLAS_FOUND)
-	  set(TPL_BLAS_LIBRARIES "${BLAS_LIBRARIES}" CACHE FILEPATH
-		"Set from FindBLAS.cmake BLAS_LIBRARIES." FORCE)
-	endif()
+  find_package(BLAS)
+  if(BLAS_FOUND)
+    set(TPL_BLAS_LIBRARIES "${BLAS_LIBRARIES}" CACHE FILEPATH
+    "Set from FindBLAS.cmake BLAS_LIBRARIES." FORCE)
+  endif()
 endif()
 
 if(BLAS_FOUND)
-    message("-- Using TPL_BLAS_LIBRARIES='${TPL_BLAS_LIBRARIES}'")
-    set(BLAS_LIB ${TPL_BLAS_LIBRARIES})
-    # fix up BLAS library name
-    string (REPLACE ";" " " BLAS_LIB_STR "${BLAS_LIB}")
-    set(BLAS_LIB_EXPORT ${BLAS_LIB_STR})
-    string(FIND ${BLAS_LIB_STR} "mkl" BUTTERFLYPACK_USE_MKL)
-    if(BUTTERFLYPACK_USE_MKL GREATER -1)
-    	set(CMAKE_Fortran_FLAGS "-DHAVE_MKL ${CMAKE_Fortran_FLAGS}")
-	    message("-- Using MKL VSL and batch GEMM")
-    endif()
- endif()
+  message("-- Using TPL_BLAS_LIBRARIES='${TPL_BLAS_LIBRARIES}'")
+  set(BLAS_LIB ${TPL_BLAS_LIBRARIES})
+  # fix up BLAS library name
+  string(REPLACE ";" " " BLAS_LIB_STR "${BLAS_LIB}")
+  set(BLAS_LIB_EXPORT ${BLAS_LIB_STR})
+  string(FIND ${BLAS_LIB_STR} "mkl" BUTTERFLYPACK_USE_MKL)
+  if(BUTTERFLYPACK_USE_MKL GREATER -1)
+    set(CMAKE_Fortran_FLAGS "-DHAVE_MKL ${CMAKE_Fortran_FLAGS}")
+    message("-- Using MKL VSL and batch GEMM")
+  endif()
+endif()
 
-
- # #--------------------- LAPACK ---------------------
+#--------------------- LAPACK ---------------------
 if(TPL_LAPACK_LIBRARIES)
-	set(LAPACK_FOUND TRUE)
+  set(LAPACK_FOUND TRUE)
 else()
-	find_package(LAPACK)
-	if(LAPACK_FOUND)
-	  set(TPL_LAPACK_LIBRARIES "${LAPACK_LIBRARIES}" CACHE FILEPATH
-		"Set from FindLAPACK.cmake LAPACK_LIBRARIES." FORCE)
-	endif()
+  find_package(LAPACK)
+  if(LAPACK_FOUND)
+    set(TPL_LAPACK_LIBRARIES "${LAPACK_LIBRARIES}" CACHE FILEPATH
+    "Set from FindLAPACK.cmake LAPACK_LIBRARIES." FORCE)
+  endif()
 endif()
 
 if(LAPACK_FOUND)
-    message("-- Using TPL_LAPACK_LIBRARIES='${TPL_LAPACK_LIBRARIES}'")
-    set(LAPACK_LIB ${TPL_LAPACK_LIBRARIES})
-    # fix up LAPACK library name
-    string (REPLACE ";" " " LAPACK_LIB_STR "${LAPACK_LIB}")
-    set(LAPACK_LIB_EXPORT ${LAPACK_LIB_STR})
- endif()
+  message("-- Using TPL_LAPACK_LIBRARIES='${TPL_LAPACK_LIBRARIES}'")
+  set(LAPACK_LIB ${TPL_LAPACK_LIBRARIES})
+  # fix up LAPACK library name
+  string(REPLACE ";" " " LAPACK_LIB_STR "${LAPACK_LIB}")
+  set(LAPACK_LIB_EXPORT ${LAPACK_LIB_STR})
+endif()
 
-  # #--------------------- SCALAPACK ---------------------
+#--------------------- SCALAPACK ---------------------
 if(TPL_SCALAPACK_LIBRARIES)
-	set(SCALAPACK_FOUND TRUE)
+  set(SCALAPACK_FOUND TRUE)
 else()
-	find_package(SCALAPACK)
-	if(SCALAPACK_FOUND)
-	  set(TPL_SCALAPACK_LIBRARIES "${SCALAPACK_LIBRARIES}" CACHE FILEPATH
-		"Set from FindSCALAPACK.cmake SCALAPACK_LIBRARIES." FORCE)
-	endif()
+  find_package(SCALAPACK)
+  if(SCALAPACK_FOUND)
+    set(TPL_SCALAPACK_LIBRARIES "${SCALAPACK_LIBRARIES}" CACHE FILEPATH
+    "Set from FindSCALAPACK.cmake SCALAPACK_LIBRARIES." FORCE)
+  endif()
 endif()
 
 if(SCALAPACK_FOUND)
-    message("-- Using TPL_SCALAPACK_LIBRARIES='${TPL_SCALAPACK_LIBRARIES}'")
-    set(SCALAPACK_LIB ${TPL_SCALAPACK_LIBRARIES})
-    # fix up LAPACK library name
-    string (REPLACE ";" " " SCALAPACK_LIB_STR "${SCALAPACK_LIB}")
-    set(SCALAPACK_LIB_EXPORT ${SCALAPACK_LIB_STR})
- endif()
+  message("-- Using TPL_SCALAPACK_LIBRARIES='${TPL_SCALAPACK_LIBRARIES}'")
+  set(SCALAPACK_LIB ${TPL_SCALAPACK_LIBRARIES})
+  # fix up ScaLAPACK library name
+  string(REPLACE ";" " " SCALAPACK_LIB_STR "${SCALAPACK_LIB}")
+  set(SCALAPACK_LIB_EXPORT ${SCALAPACK_LIB_STR})
+endif()
 
-  # #--------------------- MAGMA ---------------------
+#--------------------- MAGMA ---------------------
 if(TPL_MAGMA_LIBRARIES)
-	set(MAGMA_FOUND TRUE)
+  set(MAGMA_FOUND TRUE)
 endif()
 
 if(MAGMA_FOUND)
-    message("-- Using TPL_MAGMA_LIBRARIES='${TPL_MAGMA_LIBRARIES}'")
-    set(MAGMA_LIB ${TPL_MAGMA_LIBRARIES})
-    string (REPLACE ";" " " MAGMA_LIB_STR "${MAGMA_LIB}")
-    set(MAGMA_LIB_EXPORT ${MAGMA_LIB_STR})
-    set(CMAKE_Fortran_FLAGS "-DHAVE_MAGMA ${CMAKE_Fortran_FLAGS}")
-    set(CMAKE_C_FLAGS "-DHAVE_MAGMA ${CMAKE_C_FLAGS}")
- endif()
-
-
-# #--------------------- ARPACK ---------------------
-if(TPL_ARPACK_LIBRARIES)
-	set(CMAKE_Fortran_FLAGS "-DHAVE_ARPACK ${CMAKE_Fortran_FLAGS}")
-    message("-- Using TPL_ARPACK_LIBRARIES='${TPL_ARPACK_LIBRARIES}'")
-    set(ARPACK_LIB ${TPL_ARPACK_LIBRARIES})
-    # fix up LAPACK library name
-    string (REPLACE ";" " " ARPACK_LIB_STR "${ARPACK_LIB}")
-    set(ARPACK_LIB_EXPORT ${ARPACK_LIB_STR})
+  message("-- Using TPL_MAGMA_LIBRARIES='${TPL_MAGMA_LIBRARIES}'")
+  set(MAGMA_LIB ${TPL_MAGMA_LIBRARIES})
+  # fix up MAGMA library name
+  string(REPLACE ";" " " MAGMA_LIB_STR "${MAGMA_LIB}")
+  set(MAGMA_LIB_EXPORT ${MAGMA_LIB_STR})
+  set(CMAKE_Fortran_FLAGS "-DHAVE_MAGMA ${CMAKE_Fortran_FLAGS}")
+  set(CMAKE_C_FLAGS "-DHAVE_MAGMA ${CMAKE_C_FLAGS}")
 endif()
 
-
+#--------------------- ARPACK ---------------------
+if(TPL_ARPACK_LIBRARIES)
+  set(CMAKE_Fortran_FLAGS "-DHAVE_ARPACK ${CMAKE_Fortran_FLAGS}")
+  message("-- Using TPL_ARPACK_LIBRARIES='${TPL_ARPACK_LIBRARIES}'")
+  set(ARPACK_LIB ${TPL_ARPACK_LIBRARIES})
+  # fix up ARPACK library name
+  string(REPLACE ";" " " ARPACK_LIB_STR "${ARPACK_LIB}")
+  set(ARPACK_LIB_EXPORT ${ARPACK_LIB_STR})
+endif()
 
 #--------------------- MPI ---------------------
 find_package(MPI)
-if(MPI_Fortran_FOUND )
-    set(CMAKE_Fortran_FLAGS "${MPI_Fortran_COMPILE_FLAGS} ${CMAKE_Fortran_FLAGS}")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${MPI_C_LINK_FLAGS}" )
+if(MPI_Fortran_FOUND)
+  set(CMAKE_Fortran_FLAGS "${MPI_Fortran_COMPILE_FLAGS} ${CMAKE_Fortran_FLAGS}")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${MPI_C_LINK_FLAGS}")
 endif()
 
-
-
-#Test MPI3
+# Test MPI3
 check_cxx_source_compiles(
 "#include <mpi.h>
 #include <iostream>
-int main(int argc, char *argv[])  {
+int main(int argc, char *argv[]) {
 int x=0;
 MPI_Request req;
 
@@ -312,44 +296,40 @@ MPI_Finalize();
 return 0;
 }" BUTTERFLYPACK_USE_MPI3)
 
-if(BUTTERFLYPACK_USE_MPI3 )
-	set(CMAKE_Fortran_FLAGS "-DHAVE_MPI3 ${CMAKE_Fortran_FLAGS}")
-	message("-- Using MPI3 features")
+if(BUTTERFLYPACK_USE_MPI3)
+  set(CMAKE_Fortran_FLAGS "-DHAVE_MPI3 ${CMAKE_Fortran_FLAGS}")
+  message("-- Using MPI3 features")
 endif()
 
-
-#Test Fortran Destructo
+# Test Fortran Destructor
 check_fortran_source_compiles(
 "module MOD
-	type quant
-		contains
-		final :: finalize
-	end type quant
+  type quant
+    contains
+    final :: finalize
+  end type quant
 
-	contains
+  contains
 
-	subroutine finalize( this )
-		type(quant), intent(inout) :: this
-	end subroutine finalize
+  subroutine finalize( this )
+    type(quant), intent(inout) :: this
+  end subroutine finalize
 end module MOD
 
 PROGRAM TEST
-	use MOD
+  use MOD
 END PROGRAM TEST" BUTTERFLYPACK_USE_Finalizer SRC_EXT F90)
 
-if(BUTTERFLYPACK_USE_Finalizer )
-	set(CMAKE_Fortran_FLAGS "-DHAVE_FINAL ${CMAKE_Fortran_FLAGS}")
-	message("-- Using Fortran Finalizer features")
+if(BUTTERFLYPACK_USE_Finalizer)
+  set(CMAKE_Fortran_FLAGS "-DHAVE_FINAL ${CMAKE_Fortran_FLAGS}")
+  message("-- Using Fortran Finalizer features")
 endif()
-
 
 ######################################################################
 #
 # Include directories
 #
 ######################################################################
-
-# include_directories(${CMAKE_SOURCE_DIR}/SRC)
 include_directories(${MPI_Fortran_INCLUDE_PATH})
 include_directories(${TPL_LAPACK95_INCLUDE_DIRS})
 
@@ -358,30 +338,27 @@ include_directories(${TPL_LAPACK95_INCLUDE_DIRS})
 # Add subdirectories
 #
 ######################################################################
-
-find_program (SED_TOOL NAMES sed)
-if (NOT SED_TOOL)
-	message (FATAL_ERROR "Unable to find sed")
-endif (NOT SED_TOOL)
-
+find_program(SED_TOOL NAMES sed)
+if(NOT SED_TOOL)
+  message(FATAL_ERROR "Unable to find sed")
+endif()
 
 if(APPLE)
-
-  # by default assume BSD sed command is used on macOS
+  # By default assume BSD sed command is used on macOS
   set(USING_MACOS_SED TRUE)
   set(SED_ARG "\"\"") # mac (BSD) sed
 
-  # detect version of SED_TOOL versionL
+  # Detect version of SED_TOOL version
   message(STATUS "detecting sed version...")
-  execute_process (
-      COMMAND ${SED_TOOL} --version
-      WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
-      OUTPUT_VARIABLE SED_TOOL_VERSION
-      ERROR_QUIET
-      )
-  message( STATUS "${SED_TOOL_VERSION}" )
+  execute_process(
+    COMMAND ${SED_TOOL} --version
+    WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
+    OUTPUT_VARIABLE SED_TOOL_VERSION
+    ERROR_QUIET
+  )
+  message(STATUS "${SED_TOOL_VERSION}")
 
-  if (SED_TOOL_VERSION MATCHES ".*GNU sed.*")
+  if(SED_TOOL_VERSION MATCHES ".*GNU sed.*")
       message(STATUS "using GNU sed...")
       set(SED_ARG "") # GNU sed
       set(USING_MACOS_SED FALSE)
@@ -389,53 +366,52 @@ if(APPLE)
 
   message(STATUS "sed command [${SED_TOOL} -i ${SED_ARG}]")
 
-  execute_process (
-      COMMAND cp PrecisionPreprocessing.sh PrecisionPreprocessing_mac.sh
-      WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
+  execute_process(
+    COMMAND cp PrecisionPreprocessing.sh PrecisionPreprocessing_mac.sh
+    WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
   )
 
-  if (USING_MACOS_SED)
-    execute_process (
-        COMMAND ${SED_TOOL} -i ${SED_ARG} -e "s/sed -i/sed -i \"\"/g" PrecisionPreprocessing_mac.sh
-        WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
+  if(USING_MACOS_SED)
+    execute_process(
+      COMMAND ${SED_TOOL} -i ${SED_ARG} -e "s/sed -i/sed -i \"\"/g" PrecisionPreprocessing_mac.sh
+      WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
     )
-
-    execute_process (
-        COMMAND ${SED_TOOL} -i ${SED_ARG} -e "s/eval//g" PrecisionPreprocessing_mac.sh
-        WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
+    execute_process(
+      COMMAND ${SED_TOOL} -i ${SED_ARG} -e "s/eval//g" PrecisionPreprocessing_mac.sh
+      WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
     )
-    execute_process (
-        COMMAND ${SED_TOOL} -i ${SED_ARG} -e "/\r\"/d" PrecisionPreprocessing_mac.sh
-        WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
+    execute_process(
+      COMMAND ${SED_TOOL} -i ${SED_ARG} -e "/\r\"/d" PrecisionPreprocessing_mac.sh
+      WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
     )
-    execute_process (
-        COMMAND ${SED_TOOL} -i ${SED_ARG} -e "s/lb=.*/lb=\"[[:<:]]\"/g" PrecisionPreprocessing_mac.sh
-        WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
+    execute_process(
+      COMMAND ${SED_TOOL} -i ${SED_ARG} -e "s/lb=.*/lb=\"[[:<:]]\"/g" PrecisionPreprocessing_mac.sh
+      WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
     )
-    execute_process (
-        COMMAND ${SED_TOOL} -i ${SED_ARG} -e "s/rb=.*/rb=\"[[:>:]]\"/g" PrecisionPreprocessing_mac.sh
-        WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
+    execute_process(
+      COMMAND ${SED_TOOL} -i ${SED_ARG} -e "s/rb=.*/rb=\"[[:>:]]\"/g" PrecisionPreprocessing_mac.sh
+      WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
     )
-    execute_process (
-        COMMAND bash PrecisionPreprocessing_mac.sh ${enable_doc}
-        WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
+    execute_process(
+      COMMAND bash PrecisionPreprocessing_mac.sh ${enable_doc}
+      WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
     )
     set(PREPROC_EXPORT "PrecisionPreprocessing_mac.sh")
   else()
-    execute_process (
+    execute_process(
       COMMAND bash PrecisionPreprocessing.sh ${enable_doc}
       WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
     )
     set(PREPROC_EXPORT "PrecisionPreprocessing.sh")
-  endif()  
+  endif()
 elseif(UNIX)
-  execute_process (
-      COMMAND bash PrecisionPreprocessing.sh ${enable_doc}
-      WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
+  execute_process(
+    COMMAND bash PrecisionPreprocessing.sh ${enable_doc}
+    WORKING_DIRECTORY ${ButterflyPACK_SOURCE_DIR}
   )
   set(PREPROC_EXPORT "PrecisionPreprocessing.sh")
 else()
-	message(FATAL_ERROR "The current OS is not yet supported")
+  message(FATAL_ERROR "The current OS is not yet supported")
 endif()
 
 add_subdirectory(SRC_DOUBLE)
@@ -444,28 +420,25 @@ add_subdirectory(SRC_SINGLE)
 add_subdirectory(SRC_COMPLEX)
 add_subdirectory(EXAMPLE)
 
-
-# documentation
+# Documentation
 if(enable_doc)
-find_package(Doxygen)
-if(DOXYGEN_FOUND)
-  configure_file(${CMAKE_SOURCE_DIR}/doc/doxygen/doxygen.dox.in
-    ${CMAKE_BINARY_DIR}/doxygen.dox @ONLY)
-  add_custom_target(doc
-    ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/doxygen.dox
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    COMMENT "Generating API documentation with doxygen" VERBATIM)
+  find_package(Doxygen)
+  if(DOXYGEN_FOUND)
+    configure_file(${CMAKE_SOURCE_DIR}/doc/doxygen/doxygen.dox.in
+      ${CMAKE_BINARY_DIR}/doxygen.dox @ONLY)
+    add_custom_target(doc
+      ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/doxygen.dox
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+      COMMENT "Generating API documentation with doxygen" VERBATIM)
+  endif()
 endif()
-endif()
-
 
 configure_file(${ButterflyPACK_SOURCE_DIR}/make.inc.in ${ButterflyPACK_SOURCE_DIR}/make.inc)
 
 # Add pkg-config support
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/butterflypack.pc.in ${CMAKE_CURRENT_BINARY_DIR}/butterflypack.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/butterflypack.pc
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 set(ConfigPackageLocation lib/cmake/ButterflyPACK)
 install(EXPORT MYBPACKTargets FILE butterflypack-targets.cmake

--- a/EXAMPLE/EMCURV_Driver.f90
+++ b/EXAMPLE/EMCURV_Driver.f90
@@ -30,7 +30,9 @@ PROGRAM ButterflyPACK_IE_2D
 	use z_BPACK_factor
 	use z_BPACK_constr
 	use z_BPACK_Utilities
+#ifdef HAVE_OPENMP
 	use omp_lib
+#endif
 	use z_MISC_Utilities
 	use z_BPACK_wrapper
     implicit none

--- a/EXAMPLE/EMCURV_Eigen_Driver.f90
+++ b/EXAMPLE/EMCURV_Eigen_Driver.f90
@@ -30,7 +30,9 @@ PROGRAM ButterflyPACK_IE_2D
 	use z_BPACK_factor
 	use z_BPACK_constr
 	use z_BPACK_Utilities
+#ifdef HAVE_OPENMP
 	use omp_lib
+#endif
 	use z_MISC_Utilities
     implicit none
 

--- a/EXAMPLE/EMCURV_Module.f90
+++ b/EXAMPLE/EMCURV_Module.f90
@@ -936,11 +936,11 @@ subroutine EM_solve_CURV(bmat,option,msh,quant,ptree,stats)
         enddo
         !$omp end parallel do
 
-        n1 = OMP_get_wtime()
+        n1 = MPI_Wtime()
 
 		call z_BPACK_Solution(bmat,Current,Voltage,N_unk_loc,1,option,ptree,stats)
 
-		n2 = OMP_get_wtime()
+		n2 = MPI_Wtime()
 		stats%Time_Sol = stats%Time_Sol + n2-n1
 		call MPI_ALLREDUCE(stats%Time_Sol,rtemp,1,MPI_DOUBLE_PRECISION,MPI_MAX,ptree%Comm,ierr)
 		if(ptree%MyID==Main_ID)then
@@ -951,9 +951,9 @@ subroutine EM_solve_CURV(bmat,option,msh,quant,ptree,stats)
 		call MPI_ALLREDUCE(stats%Flop_Sol,rtemp,1,MPI_DOUBLE_PRECISION,MPI_SUM,ptree%Comm,ierr)
 		if(ptree%MyID==Main_ID .and. option%verbosity>=0)write (*,'(A13Es14.2)') 'Solve flops:',rtemp
 
-		n1 = OMP_get_wtime()
+		n1 = MPI_Wtime()
         call RCS_bistatic_CURV(Current,msh,quant,ptree)
-		n2 = OMP_get_wtime()
+		n2 = MPI_Wtime()
 
 		if(ptree%MyID==Main_ID)then
 			write (*,*) ''
@@ -976,7 +976,7 @@ subroutine EM_solve_CURV(bmat,option,msh,quant,ptree,stats)
 
         if(ptree%MyID==Main_ID)open (100, file='RCS_monostatic.txt')
 
-        n1=OMP_get_wtime()
+        n1=MPI_Wtime()
         do j=0, num_sample
             phi=j*dphi
 			!$omp parallel do default(shared) private(edge,value_Z)
@@ -1007,7 +1007,7 @@ subroutine EM_solve_CURV(bmat,option,msh,quant,ptree,stats)
 
         enddo
 
-		n2 = OMP_get_wtime()
+		n2 = MPI_Wtime()
 		stats%Time_Sol = stats%Time_Sol + n2-n1
 		call MPI_ALLREDUCE(stats%Time_Sol,rtemp,1,MPI_DOUBLE_PRECISION,MPI_MAX,ptree%Comm,ierr)
 
@@ -1098,7 +1098,7 @@ subroutine C_EMCURV_Init(Npo,Locations,quant_emcurv_Cptr, model2d, wavelength, M
    endif
    !***********************************************************************
 
-	t1 = OMP_get_wtime()
+	t1 = MPI_Wtime()
     if(MyID==Main_ID)write(*,*) "geometry modeling......"
     call geo_modeling_CURV(quant,MPIcomm)
 
@@ -1109,7 +1109,7 @@ subroutine C_EMCURV_Init(Npo,Locations,quant_emcurv_Cptr, model2d, wavelength, M
 
 	if(MyID==Main_ID)write(*,*) "modeling finished"
     if(MyID==Main_ID)write(*,*) "    "
-	t2 = OMP_get_wtime()
+	t2 = MPI_Wtime()
 	! write(*,*)t2-t1
 
 	!**** return the C address of hodlr structures to C caller

--- a/EXAMPLE/EMSURF_Driver.f90
+++ b/EXAMPLE/EMSURF_Driver.f90
@@ -31,7 +31,9 @@ PROGRAM ButterflyPACK_IE_3D
 	use z_BPACK_factor
 	use z_BPACK_constr
 	use z_BPACK_Solve_Mul
+#ifdef HAVE_OPENMP
 	use omp_lib
+#endif
 	use z_MISC_Utilities
     implicit none
 
@@ -183,7 +185,7 @@ PROGRAM ButterflyPACK_IE_3D
 	ker%FuncZmn => Zelem_EMSURF
 
 	!**** initialization of the construction phase
-	t1 = OMP_get_wtime()
+	t1 = MPI_Wtime()
 	allocate(xyz(3,quant%Nunk))
 	do ii=1, quant%Nunk
 		xyz(:,ii) = quant%xyz(:,quant%maxnode+ii)
@@ -193,7 +195,7 @@ PROGRAM ButterflyPACK_IE_3D
 	call z_BPACK_construction_Init(quant%Nunk,Permutation,Nunk_loc,bmat,option,stats,msh,ker,ptree,Coordinates=xyz)
 	deallocate(Permutation) ! caller can use this permutation vector if needed
 	deallocate(xyz)
-	t2 = OMP_get_wtime()
+	t2 = MPI_Wtime()
 
 
 

--- a/EXAMPLE/EMSURF_Driver_sp.f90
+++ b/EXAMPLE/EMSURF_Driver_sp.f90
@@ -30,7 +30,9 @@ PROGRAM ButterflyPACK_IE_3D
 	use c_BPACK_factor
 	use c_BPACK_constr
 	use c_BPACK_Solve_Mul
+#ifdef HAVE_OPENMP
 	use omp_lib
+#endif
 	use c_MISC_Utilities
 	use c_BPACK_utilities
     implicit none
@@ -180,7 +182,7 @@ PROGRAM ButterflyPACK_IE_3D
 	ker%FuncZmn => Zelem_EMSURF
 
 	!**** initialization of the construction phase
-	t1 = OMP_get_wtime()
+	t1 = MPI_Wtime()
 	allocate(xyz(3,quant%Nunk))
 	do ii=1, quant%Nunk
 		xyz(:,ii) = quant%xyz(:,quant%maxnode+ii)
@@ -190,7 +192,7 @@ PROGRAM ButterflyPACK_IE_3D
 	call c_BPACK_construction_Init(quant%Nunk,Permutation,Nunk_loc,bmat,option,stats,msh,ker,ptree,Coordinates=xyz)
 	deallocate(Permutation) ! caller can use this permutation vector if needed
 	deallocate(xyz)
-	t2 = OMP_get_wtime()
+	t2 = MPI_Wtime()
 
 
 

--- a/EXAMPLE/EMSURF_Eigen_Driver.f90
+++ b/EXAMPLE/EMSURF_Eigen_Driver.f90
@@ -30,7 +30,9 @@ PROGRAM ButterflyPACK_IE_3D
 	use z_BPACK_factor
 	use z_BPACK_constr
 	use z_BPACK_Solve_Mul
+#ifdef HAVE_OPENMP
 	use omp_lib
+#endif
 	use z_MISC_Utilities
 	use z_BPACK_utilities
     implicit none
@@ -224,7 +226,7 @@ PROGRAM ButterflyPACK_IE_3D
 	ker_A%QuantApp => quant
 	ker_A%FuncZmn => Zelem_EMSURF
 	!**** initialization of the construction phase
-	t1 = OMP_get_wtime()
+	t1 = MPI_Wtime()
 	allocate(xyz(3,quant%Nunk))
 	do ii=1, quant%Nunk
 		xyz(:,ii) = quant%xyz(:,quant%maxnode+ii)
@@ -233,7 +235,7 @@ PROGRAM ButterflyPACK_IE_3D
 	call z_BPACK_construction_Init(quant%Nunk,Permutation,Nunk_loc,bmat_A,option_A,stats_A,msh_A,ker_A,ptree_A,Coordinates=xyz)
 	deallocate(Permutation) ! caller can use this permutation vector if needed
 	deallocate(xyz)
-	t2 = OMP_get_wtime()
+	t2 = MPI_Wtime()
 	!**** computation of the construction phase
     call z_BPACK_construction_Element(bmat_A,option_A,stats_A,msh_A,ker_A,ptree_A)
 	!**** print statistics
@@ -257,7 +259,7 @@ PROGRAM ButterflyPACK_IE_3D
 		call z_CreatePtree(nmpi,groupmembers,MPI_Comm_World,ptree_sh)
 		deallocate(groupmembers)
 		!**** initialization of the construction phase
-		t1 = OMP_get_wtime()
+		t1 = MPI_Wtime()
 		allocate(xyz(3,quant%Nunk))
 		do ii=1, quant%Nunk
 			xyz(:,ii) = quant%xyz(:,quant%maxnode+ii)
@@ -266,7 +268,7 @@ PROGRAM ButterflyPACK_IE_3D
 		call z_BPACK_construction_Init(quant%Nunk,Permutation,Nunk_loc,bmat_sh,option_sh,stats_sh,msh_sh,ker_sh,ptree_sh,Coordinates=xyz)
 		deallocate(Permutation) ! caller can use this permutation vector if needed
 		deallocate(xyz)
-		t2 = OMP_get_wtime()
+		t2 = MPI_Wtime()
 		!**** computation of the construction phase
 		call z_BPACK_construction_Element(bmat_sh,option_sh,stats_sh,msh_sh,ker_sh,ptree_sh)
 		!**** factorization phase
@@ -295,7 +297,7 @@ PROGRAM ButterflyPACK_IE_3D
 		call z_CreatePtree(nmpi,groupmembers,MPI_Comm_World,ptree_B)
 		deallocate(groupmembers)
 		!**** initialization of the construction phase
-		t1 = OMP_get_wtime()
+		t1 = MPI_Wtime()
 		allocate(xyz(3,quant%Nunk))
 		do ii=1, quant%Nunk
 			xyz(:,ii) = quant%xyz(:,quant%maxnode+ii)
@@ -304,7 +306,7 @@ PROGRAM ButterflyPACK_IE_3D
 		call z_BPACK_construction_Init(quant%Nunk,Permutation,Nunk_loc,bmat_B,option_B,stats_B,msh_B,ker_B,ptree_B,Coordinates=xyz)
 		deallocate(Permutation) ! caller can use this permutation vector if needed
 		deallocate(xyz)
-		t2 = OMP_get_wtime()
+		t2 = MPI_Wtime()
 		!**** computation of the construction phase
 		call z_BPACK_construction_Element(bmat_B,option_B,stats_B,msh_B,ker_B,ptree_B)
 		!**** factorization phase

--- a/EXAMPLE/EMSURF_Module.f90
+++ b/EXAMPLE/EMSURF_Module.f90
@@ -1496,17 +1496,17 @@ subroutine EM_solve_SURF(bmat,option,msh,quant,ptree,stats)
         enddo
         !$omp end parallel do
 
-        n1 = OMP_get_wtime()
+        n1 = MPI_Wtime()
 		call z_BPACK_Solution(bmat,Current,Voltage,N_unk_loc,2,option,ptree,stats)
-		n2 = OMP_get_wtime()
+		n2 = MPI_Wtime()
 
         if(ptree%MyID==Main_ID .and. option%verbosity>=0)write (*,*) ''
         if(ptree%MyID==Main_ID .and. option%verbosity>=0)write (*,*) 'Solving:',n2-n1,'Seconds'
         if(ptree%MyID==Main_ID .and. option%verbosity>=0)write (*,*) ''
 
-		n1 = OMP_get_wtime()
+		n1 = MPI_Wtime()
         call RCS_bistatic_SURF(Current,msh,quant,ptree)
-		n2 = OMP_get_wtime()
+		n2 = MPI_Wtime()
 
 		! call current_node_patch_mapping('V',curr(:,1),msh)
 		! call current_node_patch_mapping('H',curr(:,2),msh)
@@ -1532,7 +1532,7 @@ subroutine EM_solve_SURF(bmat,option,msh,quant,ptree,stats)
 
         if(ptree%MyID==Main_ID)open (100, file='bistaticH.out')
 
-        n1=OMP_get_wtime()
+        n1=MPI_Wtime()
 
         do j=0, num_sample
             phi=j*dphi
@@ -1565,7 +1565,7 @@ subroutine EM_solve_SURF(bmat,option,msh,quant,ptree,stats)
 
         enddo
 
-		n2 = OMP_get_wtime()
+		n2 = MPI_Wtime()
 		stats%Time_Sol = stats%Time_Sol + n2-n1
 		call MPI_ALLREDUCE(stats%Time_Sol,rtemp,1,MPI_DOUBLE_PRECISION,MPI_MAX,ptree%Comm,ierr)
 

--- a/EXAMPLE/EMSURF_Module_sp.f90
+++ b/EXAMPLE/EMSURF_Module_sp.f90
@@ -1545,17 +1545,17 @@ subroutine EM_solve_SURF(bmat,option,msh,quant,ptree,stats)
         enddo
         !$omp end parallel do
 
-        n1 = OMP_get_wtime()
+        n1 = MPI_Wtime()
 		call c_BPACK_Solution(bmat,Current,Voltage,N_unk_loc,2,option,ptree,stats)
-		n2 = OMP_get_wtime()
+		n2 = MPI_Wtime()
 
         if(ptree%MyID==Main_ID .and. option%verbosity>=0)write (*,*) ''
         if(ptree%MyID==Main_ID .and. option%verbosity>=0)write (*,*) 'Solving:',n2-n1,'Seconds'
         if(ptree%MyID==Main_ID .and. option%verbosity>=0)write (*,*) ''
 
-        n1 = OMP_get_wtime()
+        n1 = MPI_Wtime()
         call RCS_bistatic_SURF(Current,msh,quant,ptree)
-		n2 = OMP_get_wtime()
+		n2 = MPI_Wtime()
 
 		! call current_node_patch_mapping('V',curr(:,1),msh)
 		! call current_node_patch_mapping('H',curr(:,2),msh)
@@ -1581,7 +1581,7 @@ subroutine EM_solve_SURF(bmat,option,msh,quant,ptree,stats)
 
         if(ptree%MyID==Main_ID)open (100, file='bistaticH.out')
 
-        n1=OMP_get_wtime()
+        n1=MPI_Wtime()
 
         do j=0, num_sample
             phi=j*dphi
@@ -1614,7 +1614,7 @@ subroutine EM_solve_SURF(bmat,option,msh,quant,ptree,stats)
 
         enddo
 
-		n2 = OMP_get_wtime()
+		n2 = MPI_Wtime()
 		stats%Time_Sol = stats%Time_Sol + n2-n1
 		call MPI_ALLREDUCE(stats%Time_Sol,rtemp,1,MPI_DOUBLE_PRECISION,MPI_MAX,ptree%Comm,ierr)
 

--- a/EXAMPLE/EMSURF_Port_Driver.f90
+++ b/EXAMPLE/EMSURF_Port_Driver.f90
@@ -31,7 +31,9 @@ PROGRAM ButterflyPACK_IE_3D
 	use z_BPACK_factor
 	use z_BPACK_constr
 	use z_BPACK_Solve_Mul
+#ifdef HAVE_OPENMP
 	use omp_lib
+#endif
 	use z_MISC_Utilities
 	use z_BPACK_utilities
     implicit none
@@ -506,7 +508,7 @@ PROGRAM ButterflyPACK_IE_3D
 	ker_A%QuantApp => quant
 	ker_A%FuncZmn => Zelem_EMSURF
 	!**** initialization of the construction phase
-	t1 = OMP_get_wtime()
+	t1 = MPI_Wtime()
 	allocate(xyz(3,quant%Nunk))
 	do ii=1, quant%Nunk_int+quant%Nunk_port
 		xyz(:,ii) = quant%xyz(:,quant%maxnode+ii)
@@ -519,7 +521,7 @@ PROGRAM ButterflyPACK_IE_3D
 	call z_BPACK_construction_Init(quant%Nunk,Permutation,Nunk_loc,bmat_A,option_A,stats_A,msh_A,ker_A,ptree_A,Coordinates=xyz)
 	deallocate(Permutation) ! caller can use this permutation vector if needed
 	deallocate(xyz)
-	t2 = OMP_get_wtime()
+	t2 = MPI_Wtime()
 	!**** computation of the construction phase
     call z_BPACK_construction_Element(bmat_A,option_A,stats_A,msh_A,ker_A,ptree_A)
 	!**** print statistics
@@ -552,7 +554,7 @@ PROGRAM ButterflyPACK_IE_3D
 			ker_sh%QuantApp => quant
 			ker_sh%FuncZmn => Zelem_EMSURF_Shifted
 			!**** initialization of the construction phase
-			t1 = OMP_get_wtime()
+			t1 = MPI_Wtime()
 			allocate(xyz(3,quant%Nunk))
 			do ii=1, quant%Nunk_int+quant%Nunk_port
 				xyz(:,ii) = quant%xyz(:,quant%maxnode+ii)
@@ -564,7 +566,7 @@ PROGRAM ButterflyPACK_IE_3D
 			call z_BPACK_construction_Init(quant%Nunk,Permutation,Nunk_loc,bmat_sh,option_sh,stats_sh,msh_sh,ker_sh,ptree_sh,Coordinates=xyz)
 			deallocate(Permutation) ! caller can use this permutation vector if needed
 			deallocate(xyz)
-			t2 = OMP_get_wtime()
+			t2 = MPI_Wtime()
 			!**** computation of the construction phase
 			call z_BPACK_construction_Element(bmat_sh,option_sh,stats_sh,msh_sh,ker_sh,ptree_sh)
 		endif

--- a/EXAMPLE/EMSURF_Port_Eigen_Driver.f90
+++ b/EXAMPLE/EMSURF_Port_Eigen_Driver.f90
@@ -30,7 +30,9 @@ PROGRAM ButterflyPACK_IE_3D
 	use z_BPACK_factor
 	use z_BPACK_constr
 	use z_BPACK_Solve_Mul
+#ifdef HAVE_OPENMP
 	use omp_lib
+#endif
 	use z_MISC_Utilities
 	use z_BPACK_utilities
     implicit none
@@ -482,7 +484,7 @@ PROGRAM ButterflyPACK_IE_3D
 	ker_A%QuantApp => quant
 	ker_A%FuncZmn => Zelem_EMSURF
 	!**** initialization of the construction phase
-	t1 = OMP_get_wtime()
+	t1 = MPI_Wtime()
 	allocate(xyz(3,quant%Nunk))
 	do ii=1, quant%Nunk_int+quant%Nunk_port
 		xyz(:,ii) = quant%xyz(:,quant%maxnode+ii)
@@ -495,7 +497,7 @@ PROGRAM ButterflyPACK_IE_3D
 	call z_BPACK_construction_Init(quant%Nunk,Permutation,Nunk_loc,bmat_A,option_A,stats_A,msh_A,ker_A,ptree_A,Coordinates=xyz)
 	deallocate(Permutation) ! caller can use this permutation vector if needed
 	deallocate(xyz)
-	t2 = OMP_get_wtime()
+	t2 = MPI_Wtime()
 	!**** computation of the construction phase
     call z_BPACK_construction_Element(bmat_A,option_A,stats_A,msh_A,ker_A,ptree_A)
 	!**** print statistics
@@ -528,7 +530,7 @@ PROGRAM ButterflyPACK_IE_3D
 			ker_sh%QuantApp => quant
 			ker_sh%FuncZmn => Zelem_EMSURF_Shifted
 			!**** initialization of the construction phase
-			t1 = OMP_get_wtime()
+			t1 = MPI_Wtime()
 			allocate(xyz(3,quant%Nunk))
 			do ii=1, quant%Nunk_int+quant%Nunk_port
 				xyz(:,ii) = quant%xyz(:,quant%maxnode+ii)
@@ -540,7 +542,7 @@ PROGRAM ButterflyPACK_IE_3D
 			call z_BPACK_construction_Init(quant%Nunk,Permutation,Nunk_loc,bmat_sh,option_sh,stats_sh,msh_sh,ker_sh,ptree_sh,Coordinates=xyz)
 			deallocate(Permutation) ! caller can use this permutation vector if needed
 			deallocate(xyz)
-			t2 = OMP_get_wtime()
+			t2 = MPI_Wtime()
 			!**** computation of the construction phase
 			call z_BPACK_construction_Element(bmat_sh,option_sh,stats_sh,msh_sh,ker_sh,ptree_sh)
 		endif
@@ -572,7 +574,7 @@ PROGRAM ButterflyPACK_IE_3D
 		call z_CreatePtree(nmpi,groupmembers,MPI_Comm_World,ptree_B)
 		deallocate(groupmembers)
 		!**** initialization of the construction phase
-		t1 = OMP_get_wtime()
+		t1 = MPI_Wtime()
 		allocate(xyz(3,quant%Nunk))
 		do ii=1, quant%Nunk_int+quant%Nunk_port
 			xyz(:,ii) = quant%xyz(:,quant%maxnode+ii)
@@ -584,7 +586,7 @@ PROGRAM ButterflyPACK_IE_3D
 		call z_BPACK_construction_Init(quant%Nunk,Permutation,Nunk_loc,bmat_B,option_B,stats_B,msh_B,ker_B,ptree_B,Coordinates=xyz)
 		deallocate(Permutation) ! caller can use this permutation vector if needed
 		deallocate(xyz)
-		t2 = OMP_get_wtime()
+		t2 = MPI_Wtime()
 		!**** computation of the construction phase
 		call z_BPACK_construction_Element(bmat_B,option_B,stats_B,msh_B,ker_B,ptree_B)
 		!**** factorization phase
@@ -825,7 +827,7 @@ PROGRAM ButterflyPACK_IE_3D
 		call z_CreatePtree(nmpi,groupmembers,MPI_Comm_World,ptree_post)
 		deallocate(groupmembers)
 		!**** initialization of the construction phase
-		t1 = OMP_get_wtime()
+		t1 = MPI_Wtime()
 		allocate(xyz(3,quant%Nunk))
 		do ii=1, quant%Nunk_int+quant%Nunk_port
 			xyz(:,ii) = quant%xyz(:,quant%maxnode+ii)
@@ -837,7 +839,7 @@ PROGRAM ButterflyPACK_IE_3D
 		call z_BPACK_construction_Init(quant%Nunk,Permutation,Nunk_loc,bmat_post,option_post,stats_post,msh_post,ker_post,ptree_post,Coordinates=xyz)
 		deallocate(Permutation) ! caller can use this permutation vector if needed
 		deallocate(xyz)
-		t2 = OMP_get_wtime()
+		t2 = MPI_Wtime()
 		!**** computation of the construction phase
 		call z_BPACK_construction_Element(bmat_post,option_post,stats_post,msh_post,ker_post,ptree_post)
 		allocate(E_normal(Nunk_loc,quant%nev))

--- a/EXAMPLE/FULLMATKERREG_Driver.f90
+++ b/EXAMPLE/FULLMATKERREG_Driver.f90
@@ -83,7 +83,9 @@ PROGRAM ButterflyPACK_FullKRR
 	use d_BPACK_structure
 	use d_BPACK_factor
 	use d_BPACK_constr
+#ifdef HAVE_OPENMP
 	use omp_lib
+#endif
 	use d_MISC_Utilities
 	use d_BPACK_utilities
 
@@ -220,7 +222,7 @@ PROGRAM ButterflyPACK_FullKRR
 	call d_PrintOptions(option,ptree)
 
 
-	t1 = OMP_get_wtime()
+	t1 = MPI_Wtime()
     if(ptree%MyID==Main_ID .and. option%verbosity>=0)write(*,*) "reading fullmatrix......"
 	allocate(quant%perms(quant%ntrain+quant%ntest))
 	do ii=1,quant%ntrain+quant%ntest
@@ -241,7 +243,7 @@ PROGRAM ButterflyPACK_FullKRR
 	deallocate(tmpline)
     if(ptree%MyID==Main_ID .and. option%verbosity>=0)write(*,*) "reading fullmatrix finished"
     if(ptree%MyID==Main_ID .and. option%verbosity>=0)write(*,*) "    "
-	t2 = OMP_get_wtime()
+	t2 = MPI_Wtime()
 
 	!**** register the user-defined function and type in ker
 	ker%QuantApp => quant
@@ -286,7 +288,9 @@ subroutine FULLKER_solve(bmat,option,msh,quant,ptree,stats)
 
     use d_BPACK_DEFS
 	use APPLICATION_MODULE
+#ifdef HAVE_OPENMP
 	use omp_lib
+#endif
 	use d_BPACK_Solve_Mul
 	use d_MISC_Utilities
 
@@ -346,11 +350,11 @@ subroutine FULLKER_solve(bmat,option,msh,quant,ptree,stats)
 	deallocate(labels)
 
 
-	n1 = OMP_get_wtime()
+	n1 = MPI_Wtime()
 
 	call d_BPACK_Solution(bmat,x,b,N_unk_loc,1,option,ptree,stats)
 
-	n2 = OMP_get_wtime()
+	n2 = MPI_Wtime()
 	stats%Time_Sol = stats%Time_Sol + n2-n1
 	call MPI_ALLREDUCE(stats%Time_Sol,rtemp,1,MPI_DOUBLE_PRECISION,MPI_MAX,ptree%Comm,ierr)
 	if(ptree%MyID==Main_ID .and. option%verbosity>=0)write (*,*) 'Solving:',rtemp,'Seconds'
@@ -375,7 +379,7 @@ subroutine FULLKER_solve(bmat,option,msh,quant,ptree,stats)
 
 
 
-	T0 = OMP_get_wtime()
+	T0 = MPI_Wtime()
 
 	allocate (vout(ntest,1))
 	allocate (vout_tmp(ntest,1))
@@ -412,7 +416,7 @@ subroutine FULLKER_solve(bmat,option,msh,quant,ptree,stats)
 		! vout=0
 		! call d_gemmf90(matrixtemp,ntest,x,N_unk,vout,ntest,'N','N',ntest,1,N_unk,BPACK_cone,BPACK_czero)
 
-	T1 = OMP_get_wtime()
+	T1 = MPI_Wtime()
 	if (ptree%MyID==Main_ID) then
 		vout_tmp = vout-vout_test
 		error=0

--- a/EXAMPLE/FULLMAT_Driver.f90
+++ b/EXAMPLE/FULLMAT_Driver.f90
@@ -144,7 +144,9 @@ PROGRAM ButterflyPACK_FULL
 	use d_BPACK_structure
 	use d_BPACK_factor
 	use d_BPACK_constr
+#ifdef HAVE_OPENMP
 	use omp_lib
+#endif
 	use d_MISC_Utilities
 	use d_BPACK_constr
 	use d_BPACK_randomMVP

--- a/EXAMPLE/FULLMAT_Driver_simple.f90
+++ b/EXAMPLE/FULLMAT_Driver_simple.f90
@@ -86,7 +86,9 @@ PROGRAM ButterflyPACK_TEMPLATE
 	use z_BPACK_structure
 	use z_BPACK_factor
 	use z_BPACK_constr
+#ifdef HAVE_OPENMP
 	use omp_lib
+#endif
 	use z_MISC_Utilities
 	use z_BPACK_constr
 	use z_BPACK_utilities

--- a/EXAMPLE/FrontalDist_Driver.f90
+++ b/EXAMPLE/FrontalDist_Driver.f90
@@ -201,7 +201,7 @@ contains
 
 
 
-		t1 = OMP_get_wtime()
+		t1 = MPI_Wtime()
 		if(ptree%MyID==Main_ID .and. option%verbosity>=0)write(*,*) "Generating fullmat ......"
 		write(smyrow , *) myrow
 		write(smycol , *) mycol
@@ -221,7 +221,7 @@ contains
 
 
 		if(ptree%MyID==Main_ID .and. option%verbosity>=0)write(*,*) "Generating fullmat finished"
-		t2 = OMP_get_wtime()
+		t2 = MPI_Wtime()
 		if(ptree%MyID==Main_ID .and. option%verbosity>=0)write(*,*)t2-t1, 'secnds'
 
 
@@ -242,7 +242,9 @@ PROGRAM ButterflyPACK_FrontalMatrix_Matvec
 	use z_BPACK_structure
 	use z_BPACK_factor
 	use z_BPACK_constr
+#ifdef HAVE_OPENMP
 	use omp_lib
+#endif
 	use z_Bplus_compress
 	use z_BPACK_randomMVP
 	use z_BPACK_utilities

--- a/EXAMPLE/Frontal_Driver.f90
+++ b/EXAMPLE/Frontal_Driver.f90
@@ -236,7 +236,9 @@ PROGRAM ButterflyPACK_FrontalMatrix_Matvec
 	use d_BPACK_structure
 	use d_BPACK_factor
 	use d_BPACK_constr
+#ifdef HAVE_OPENMP
 	use omp_lib
+#endif
 	use d_Bplus_compress
 	use d_BPACK_randomMVP
 	use d_BPACK_utilities
@@ -359,7 +361,7 @@ PROGRAM ButterflyPACK_FrontalMatrix_Matvec
 
 
 	!**** generate the full matrix used for entry evaluation function Zelem_FULL
-	t1 = OMP_get_wtime()
+	t1 = MPI_Wtime()
 	if(ptree%MyID==Main_ID .and. option%verbosity>=0)write(*,*) "Generating fullmat ......"
 	allocate(quant%matZ_glo(quant%Nunk,quant%Nunk))
 	quant%matZ_glo = 0
@@ -374,7 +376,7 @@ PROGRAM ButterflyPACK_FrontalMatrix_Matvec
 	close(unit=888)
 	deallocate(tmp)
 	if(ptree%MyID==Main_ID .and. option%verbosity>=0)write(*,*) "Generating fullmat finished"
-	t2 = OMP_get_wtime()
+	t2 = MPI_Wtime()
 	if(ptree%MyID==Main_ID .and. option%verbosity>=0)write(*,*)t2-t1, 'secnds'
 
 	! allocate(tree(32))

--- a/EXAMPLE/SMAT_Driver.f90
+++ b/EXAMPLE/SMAT_Driver.f90
@@ -231,7 +231,9 @@ PROGRAM ButterflyPACK_ScatteringMatrix_Matvec
 	use z_BPACK_structure
 	use z_BPACK_factor
 	use z_BPACK_constr
+#ifdef HAVE_OPENMP
 	use omp_lib
+#endif
 	use z_Bplus_compress
 	use z_BPACK_randomMVP
 	use z_BPACK_utilities
@@ -372,7 +374,7 @@ PROGRAM ButterflyPACK_ScatteringMatrix_Matvec
 
 
 	!**** generate the full matrix used for entry evaluation function Zelem_FULL
-	t1 = OMP_get_wtime()
+	t1 = MPI_Wtime()
 	if(ptree%MyID==Main_ID .and. option%verbosity>=0)write(*,*) "Generating fullmat ......"
 	allocate(quant%matZ_glo(quant%Nunk,quant%Nunk))
 	quant%matZ_glo = 0
@@ -385,7 +387,7 @@ PROGRAM ButterflyPACK_ScatteringMatrix_Matvec
 	end do
 	close(unit=888)
 	if(ptree%MyID==Main_ID .and. option%verbosity>=0)write(*,*) "Generating fullmat finished"
-	t2 = OMP_get_wtime()
+	t2 = MPI_Wtime()
 	if(ptree%MyID==Main_ID .and. option%verbosity>=0)write(*,*)t2-t1, 'secnds'
 
 

--- a/SRC/BPACK_solve_mul.f90
+++ b/SRC/BPACK_solve_mul.f90
@@ -76,7 +76,7 @@ contains
 
 #if DAT==0
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
       maxn = Nunk
       ldv = Nunk_loc
       maxnev = nev
@@ -285,7 +285,7 @@ contains
          end if
 
       endif
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
       if (ptree_A%MyID == Main_ID .and. option_A%verbosity >= 0) write (*, *) 'Eigen Solve time: ', t2 - t1
 
       deallocate (select)
@@ -330,7 +330,7 @@ contains
       DT, allocatable::r0_initial(:)
       real(kind=8) n1, n2, rtemp
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       if (option%precon /= DIRECT) then
          allocate (r0_initial(1:Ns_loc))
@@ -350,7 +350,7 @@ contains
          stats%Flop_Sol = stats%Flop_Sol + stats%Flop_Tmp
       end if
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       stats%Time_Sol = stats%Time_Sol + n2 - n1
 
       return
@@ -953,7 +953,7 @@ contains
       integer::dist, kerflag
       integer::idxs_i,idxe_i, idxs_o,idxe_o
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       Ncol = num_vectors
       tag = 1
 
@@ -1171,7 +1171,7 @@ contains
          if (allocated(recvquant(pp)%dat)) deallocate (recvquant(pp)%dat)
       enddo
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
 
@@ -1212,7 +1212,7 @@ contains
       integer::dist, kerflag
       integer::idxs_i,idxe_i, idxs_o,idxe_o
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       Vin=0
       tag = 1
       Ncol = num_vectors
@@ -1418,7 +1418,7 @@ contains
          if (allocated(recvquant(pp)%dat)) deallocate (recvquant(pp)%dat)
       enddo
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
 
@@ -1607,7 +1607,7 @@ contains
 
          ! call MPI_barrier(ptree%Comm, ierr)
 
-         n1 = OMP_get_wtime()
+         n1 = MPI_Wtime()
 
          do i = 1, h_mat%myArows
             do j = 1, h_mat%myAcols
@@ -1659,7 +1659,7 @@ contains
          Vout = Vout/option%scale_factor
 
          call MPI_barrier(ptree%Comm, ierr)
-         n2 = OMP_get_wtime()
+         n2 = MPI_Wtime()
 
          ! vecnorm = fnorm(Vout, Ns, num_vectors)**2d0
          ! call MPI_AllREDUCE(MPI_IN_PLACE, vecnorm, 1, MPI_double, MPI_SUM, ptree%Comm, ierr)

--- a/SRC/BPACK_structure.f90
+++ b/SRC/BPACK_structure.f90
@@ -905,17 +905,22 @@ end function distance_geo
 
 !$omp threadprivate(my_tid)
 
+#ifdef HAVE_OPENMP
 !$omp parallel default(shared)
 !$omp master
       num_threads = omp_get_num_threads()
 !$omp end master
       my_tid = omp_get_thread_num()
 !$omp end parallel
+#else
+      num_threads = 1
+      my_tid = 0
+#endif
 
 
       tmp=0
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
       allocate (msh%nns(msh%Nunk, option%knn))
       call LogMemory(stats, SIZEOF(msh%nns)/1024.0d3)
       msh%nns = 0
@@ -1042,7 +1047,7 @@ end function distance_geo
       deallocate (order)
       deallocate (edge_temp)
 
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) "Finding neighbours time: ", t2 - t1
 
    end subroutine FindKNNs

--- a/SRC/BPACK_wrapper.f90
+++ b/SRC/BPACK_wrapper.f90
@@ -23,7 +23,9 @@ module BPACK_wrapper
    use BPACK_factor
    use BPACK_constr
    use BPACK_randomMVP
+#ifdef HAVE_OPENMP
    use omp_lib
+#endif
    use MISC_Utilities
    use BPACK_Solve_Mul
    use iso_c_binding
@@ -940,11 +942,11 @@ contains
       ker%C_FuncZmn => C_FuncZmn
       ker%C_FuncZmnBlock => C_FuncZmnBlock
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
       !>**** computation of the construction phase
       call BPACK_construction_Element(bmat, option, stats, msh, ker, ptree)
       ! call BPACK_CheckError(bmat,option,msh,ker,stats,ptree)
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
 
       !>**** delete neighours in msh
       if(allocated(msh%nns))then
@@ -1048,7 +1050,9 @@ contains
          read (strings, *) threads_num
       endif
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) 'OMP_NUM_THREADS=', threads_num
+#ifdef HAVE_OPENMP
       call OMP_set_num_threads(threads_num)
+#endif
 
       !>**** create a random seed
       ! call DATE_AND_TIME(values=times)     ! Get the current time
@@ -1071,7 +1075,7 @@ contains
 
       msh%Nunk = N
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
 
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) "User-supplied kernel:"
       Maxlevel = nlevel
@@ -1115,15 +1119,15 @@ contains
       endif
 
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) "    "
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) "Hierarchical format......"
       call Cluster_partition(bmat, option, msh, ker, stats, ptree)
       call BPACK_structuring(bmat, option, msh, ker, ptree, stats)
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) "Hierarchical format finished"
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) "    "
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
 
       if ((option%nogeo == 3 .or. option%nogeo == 4) .and. option%knn > 0) then
          allocate (msh%nns(msh%Nunk, option%knn))
@@ -1262,7 +1266,9 @@ contains
          read (strings, *) threads_num
       endif
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) 'OMP_NUM_THREADS=', threads_num
+#ifdef HAVE_OPENMP
       call OMP_set_num_threads(threads_num)
+#endif
 
       !>**** create a random seed
       ! call DATE_AND_TIME(values=times)     ! Get the current time
@@ -1283,7 +1289,7 @@ contains
 
       msh%Nunk = N
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
 
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) "User-supplied kernel:"
       Maxlevel = nlevel
@@ -1327,15 +1333,15 @@ contains
       endif
 
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) "    "
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) "Hierarchical format......"
       call Cluster_partition(bmat, option, msh, ker, stats, ptree)
       call BPACK_structuring(bmat, option, msh, ker, ptree, stats)
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) "Hierarchical format finished"
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) "    "
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
 
       if ((option%nogeo == 3 .or. option%nogeo == 4) .and. option%knn > 0) then
          allocate (msh%nns(msh%Nunk, option%knn))
@@ -1508,7 +1514,9 @@ contains
          read (strings, *) threads_num
       endif
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) 'OMP_NUM_THREADS=', threads_num
+#ifdef HAVE_OPENMP
       call OMP_set_num_threads(threads_num)
+#endif
 
       !>**** create a random seed
       ! call DATE_AND_TIME(values=times)     ! Get the current time
@@ -1678,7 +1686,7 @@ contains
       ker%C_QuantApp => C_QuantApp
       ker%C_FuncBMatVec => C_FuncBMatVec
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) " "
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) "FastMATVEC-based BF construction......"
 
@@ -1686,7 +1694,7 @@ contains
 
       call BF_ComputeMemory(blocks, stats%Mem_Comp_for)
 
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
 
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) "FastMATVEC-based BF construction finished in", t2-t1, 'Seconds with', stats%Mem_Comp_for,'MB Memory'
 
@@ -1769,7 +1777,7 @@ contains
       ker%C_FuncZmnBlock => C_FuncZmnBlock
       ker%C_FuncZmn => C_FuncZmn
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) " "
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) "EntryExtraction-based BF construction......"
 
@@ -1809,7 +1817,7 @@ contains
          deallocate(msh%nns)
       endif
 
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
 
       if (ptree%MyID == Main_ID .and. option%verbosity >= 0) write (*, *) "EntryExtraction-based BF construction finished in", t2-t1, 'Seconds with', Memory,'MB Memory'
 
@@ -1949,7 +1957,7 @@ contains
 
       type(proctree), pointer::ptree
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
 
       strlen = 1
       ! do while(trans(strlen) /= c_null_char)
@@ -1973,7 +1981,7 @@ contains
          call BF_block_MVP_dat(blocks, trim(str), Ninloc, Noutloc, Ncol, xin, Ninloc, xout, Noutloc, BPACK_cone, BPACK_czero, ptree, stats)
       endif
 
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
 
       xout = xout/option%scale_factor
 
@@ -2049,7 +2057,7 @@ contains
       type(mesh), pointer::msh
       real(kind=8) t1, t2
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
 
       call c_f_pointer(block_Cptr, blocks_o)
       call c_f_pointer(option_Cptr, option)
@@ -2083,7 +2091,7 @@ contains
       deallocate (allcols1)
       deallocate (pgidx1)
 
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
 
       stats%Time_C_Extract = stats%Time_C_Extract + t2 - t1
       stats%Flop_C_Extract = stats%Flop_C_Extract + stats%Flop_Tmp
@@ -2132,7 +2140,7 @@ contains
       integer::Npmap, pmaps(Npmap, 3)
       real(kind=8) t1, t2
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
 
       call c_f_pointer(bmat_Cptr, bmat)
       call c_f_pointer(option_Cptr, option)
@@ -2158,7 +2166,7 @@ contains
       deallocate (allcols1)
       deallocate (pgidx1)
 
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
 
       stats%Time_C_Extract = stats%Time_C_Extract + t2 - t1
       stats%Flop_C_Extract = stats%Flop_C_Extract + stats%Flop_Tmp
@@ -2195,7 +2203,7 @@ contains
       type(Bmatrix), pointer::bmat
       type(proctree), pointer::ptree
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
 
       strlen = 1
       ! do while(trans(strlen) /= c_null_char)
@@ -2223,7 +2231,7 @@ contains
       ! if(ptree%MyID==Main_ID .and. option%verbosity>=0)write(*,*) "Multiply finished"
       ! if(ptree%MyID==Main_ID .and. option%verbosity>=0)write(*,*) "    "
 
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
 
       stats%Time_C_Mult = stats%Time_C_Mult + t2 - t1
       stats%Flop_C_Mult = stats%Flop_C_Mult + stats%Flop_Tmp
@@ -2263,7 +2271,7 @@ contains
 
       type(proctree), pointer::ptree
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
 
       strlen = 1
       ! do while(trans(strlen) /= c_null_char)
@@ -2291,7 +2299,7 @@ contains
       ! if(ptree%MyID==Main_ID .and. option%verbosity>=0)write(*,*) "Multiply finished"
       ! if(ptree%MyID==Main_ID .and. option%verbosity>=0)write(*,*) "    "
 
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
 
       stats%Time_C_Mult = stats%Time_C_Mult + t2 - t1
       stats%Flop_C_Mult = stats%Flop_C_Mult + stats%Flop_Tmp

--- a/SRC/Bplus_compress.f90
+++ b/SRC/Bplus_compress.f90
@@ -157,7 +157,7 @@ contains
                submats(index_ij)%nr=0
                submats(index_ij)%nc=0
             enddo
-            n1 = OMP_get_wtime()
+            n1 = MPI_Wtime()
 
             nnz_loc=0
             do index_ij = 1, nr*nc
@@ -167,7 +167,7 @@ contains
                index_j = (index_j_loc - 1)*inc_c + idx_c
                call BF_compress_NlogN_oneblock_R_sample(submats,blocks, boundary_map, Nboundall, groupm_start, option, stats, msh, ker, ptree, index_i, index_j, index_ij,level, nnz_loc, flops1)
             enddo
-            n2 = OMP_get_wtime()
+            n2 = MPI_Wtime()
             ! time_tmp = time_tmp + n2 - n1
             if(Nboundall==0)then ! Nboundall>0 means there are intersections with masks, which cannot use contiguous buffers yet.
                allocate(alldat_loc_in(nnz_loc))
@@ -271,7 +271,7 @@ contains
                allocate (blocks%ButterflySkel(level)%inds(blocks%ButterflySkel(level)%nr, blocks%ButterflySkel(level)%nc))
             endif
 
-            n1 = OMP_get_wtime()
+            n1 = MPI_Wtime()
             allocate(submats(nr*nc))
             do index_ij = 1, nr*nc
                submats(index_ij)%nr=0
@@ -286,7 +286,7 @@ contains
                call BF_compress_NlogN_oneblock_C_sample(submats,blocks, boundary_map, Nboundall, groupm_start, option, stats, msh, ker, ptree, index_i, index_j, index_ij, level, level_final, nnz_loc)
             enddo
             ! !$omp end parallel do
-            n2 = OMP_get_wtime()
+            n2 = MPI_Wtime()
             ! time_tmp = time_tmp + n2 - n1
             if(Nboundall==0)then ! Nboundall>0 means there are intersections with masks, which cannot use contiguous buffers yet.
                allocate(alldat_loc_in(nnz_loc))
@@ -848,7 +848,7 @@ contains
 
       real(kind=8)::n1, n2
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       if (mode == 'R') modetrans = 'C'
       if (mode == 'C') modetrans = 'R'
@@ -1059,7 +1059,7 @@ contains
       deallocate (recvquant)
       deallocate (sendIDactive)
       deallocate (recvIDactive)
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
    end subroutine BF_exchange_skel
@@ -1104,7 +1104,7 @@ contains
       integer, allocatable::sendbufall2all(:), recvbufall2all(:)
       integer::dist
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       call assert(mode /= mode_new, 'only row2col or col2row is supported')
 
@@ -1303,7 +1303,7 @@ contains
       deallocate (sendIDactive)
       deallocate (recvIDactive)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
    end subroutine BF_all2all_skel
@@ -2029,7 +2029,7 @@ contains
 
             end do
 
-            n1 = OMP_get_wtime()
+            n1 = MPI_Wtime()
 
             do level_loc = 1, level_butterflyL
                level = level_loc + levelm
@@ -2106,7 +2106,7 @@ contains
                end if
 
             end do
-            n2 = OMP_get_wtime()
+            n2 = MPI_Wtime()
             ! time_tmp = time_tmp + n2 - n1
 
          enddo
@@ -2182,7 +2182,7 @@ contains
                deallocate (SVD_Q%matU, SVD_Q%matV, SVD_Q%Singular, mat_tmp)
             end do
 
-            n1 = OMP_get_wtime()
+            n1 = MPI_Wtime()
             do level_loc = 1, level_butterflyR
                level = levelm + 1 - level_loc
 
@@ -2358,7 +2358,7 @@ contains
 
             end do
 
-            n2 = OMP_get_wtime()
+            n2 = MPI_Wtime()
             ! time_tmp = time_tmp + n2 - n1
          enddo
 
@@ -2594,7 +2594,7 @@ if(option%elem_extract>=1)then ! advancing multiple acas for entry extraction
          endif
 
 
-         n1 = OMP_get_wtime()
+         n1 = MPI_Wtime()
 
          nrc=nr*nc
          allocate(submats(max(1,nrc*2)))  ! odd for columns, even for rows
@@ -3198,7 +3198,7 @@ endif
 
 
 
-n2 = OMP_get_wtime()
+n2 = MPI_Wtime()
 time_tmp = time_tmp + n2 - n1
 
 
@@ -3240,7 +3240,7 @@ time_tmp = time_tmp + n2 - n1
          call BF_delete_ker_onelevel(ButterflyP_old1)
 
 
-         n1 = OMP_get_wtime()
+         n1 = MPI_Wtime()
          ! construct the the left half
          do level = level_half+1, level_butterfly
             !>*** Caution!! the left half is row-wise, the right half is column-wise
@@ -3293,7 +3293,7 @@ time_tmp = time_tmp + n2 - n1
             call BF_all2all_vec_n_ker(blocks, blocks%ButterflyKerl(level), stats, ptree, ptree%pgrp(blocks%pgno)%nproc, level, 'R', 'C', 1)
 
          enddo
-         n2 = OMP_get_wtime()
+         n2 = MPI_Wtime()
          ! time_tmp = time_tmp + n2 - n1
          call BF_delete_ker_onelevel(ButterflyMiddle)
 
@@ -3313,7 +3313,7 @@ time_tmp = time_tmp + n2 - n1
          deallocate (ButterflyP_old%blocks)
 
          ! construct the the right half
-         n1 = OMP_get_wtime()
+         n1 = MPI_Wtime()
          do level = level_half, 1, -1
             !>*** Caution!! the left half is row-wise, the right half is column-wise
             call GetLocalBlockRange(ptree, blocks%pgno, level, level_butterfly, idx_r, inc_r, nr, idx_c, inc_c, nc, 'C')
@@ -3364,7 +3364,7 @@ time_tmp = time_tmp + n2 - n1
             call BF_all2all_vec_n_ker(blocks, blocks%ButterflyKerl(level), stats, ptree, ptree%pgrp(blocks%pgno)%nproc, level, 'C', 'R', 1)
          end do
 
-         n2 = OMP_get_wtime()
+         n2 = MPI_Wtime()
          ! time_tmp = time_tmp + n2 - n1
 
 
@@ -4475,7 +4475,7 @@ time_tmp = time_tmp + n2 - n1
       allocate (norm_UVavrbynorm_Z(Navr))
       norm_UVavrbynorm_Z = 0
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       allocate (select_column(rankmax_c))
       allocate (select_row(rankmax_r))
@@ -4876,7 +4876,7 @@ time_tmp = time_tmp + n2 - n1
       deallocate (norm_row_R, norm_column_R)
       deallocate (norm_UVavrbynorm_Z)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
 ! ACA followed by SVD
@@ -5005,7 +5005,7 @@ time_tmp = time_tmp + n2 - n1
       allocate (norm_UVavrbynorm_Z(Navr))
       norm_UVavrbynorm_Z = 0
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       allocate (value_UV(max(N, M)))
       value_UV = 0
@@ -5318,7 +5318,7 @@ time_tmp = time_tmp + n2 - n1
 
       deallocate (norm_UVavrbynorm_Z)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
 ! ! ACA followed by SVD
@@ -5587,7 +5587,7 @@ time_tmp = time_tmp + n2 - n1
       type(intersect)::submats(1)
       type(SVD_quant)::SVD_Q
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       rmax = size(SVD_Q%MatU,2)
       rankmax_min = min(M, N)
@@ -5867,7 +5867,7 @@ time_tmp = time_tmp + n2 - n1
       ! deallocate(core_inv)
       deallocate (perms)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
       return
@@ -5904,7 +5904,7 @@ time_tmp = time_tmp + n2 - n1
       integer::passflag = 0
       type(SVD_quant)::SVD_Q
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       rmax = size(SVD_Q%MatU,2)
       rankmax_min = min(M, N)
@@ -6329,7 +6329,7 @@ time_tmp = time_tmp + n2 - n1
       deallocate (columns)
       deallocate (rows)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
       return
@@ -6367,7 +6367,7 @@ time_tmp = time_tmp + n2 - n1
       type(Hoption)::option
       integer rcflag ! rows or columns passed in
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
 
       flops=0
@@ -6553,7 +6553,7 @@ time_tmp = time_tmp + n2 - n1
       deallocate (perms)
 
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
       return

--- a/SRC/Bplus_factor.f90
+++ b/SRC/Bplus_factor.f90
@@ -41,7 +41,7 @@ contains
       type(matrixblock) :: blocks
       real(kind=8) flop
 
-      T0 = OMP_get_wtime()
+      T0 = MPI_Wtime()
       size_m = size(blocks%fullmat, 1)
       if (option%ILU == 0) then
          ! do ii=1,size_m
@@ -61,7 +61,7 @@ contains
             blocks%ipiv(ii) = ii
          enddo
       endif
-      T1 = OMP_get_wtime()
+      T1 = MPI_Wtime()
       stats%Time_Direct_LU = stats%Time_Direct_LU + T1 - T0
 
       return
@@ -88,7 +88,7 @@ contains
 
       stats%Flop_Tmp = 0
 
-      T0 = OMP_get_wtime()
+      T0 = MPI_Wtime()
       style(3) = block3%style
       level_blocks = block3%level
 
@@ -119,7 +119,7 @@ contains
       deallocate (Vin)
       deallocate (Vin1)
 
-      T1 = OMP_get_wtime()
+      T1 = MPI_Wtime()
       stats%Time_Add_Multiply = stats%Time_Add_Multiply + T1 - T0
       stats%Flop_Factor = stats%Flop_Factor + stats%Flop_Tmp
 
@@ -148,7 +148,7 @@ contains
       style(1) = block1%style
       level_blocks = block3%level
 
-      T0 = OMP_get_wtime()
+      T0 = MPI_Wtime()
       call assert(style(1) /= 1, 'block1 not supposed to be full')
       call assert(style(3) == 1, 'block3 supposed to be full')
 
@@ -175,7 +175,7 @@ contains
       deallocate (fullmatrix)
       deallocate (Vin)
 
-      T1 = OMP_get_wtime()
+      T1 = MPI_Wtime()
       stats%Time_Add_Multiply = stats%Time_Add_Multiply + T1 - T0
       stats%Flop_Factor = stats%Flop_Factor + stats%Flop_Tmp
       return
@@ -495,7 +495,7 @@ contains
          idx_end_diag = min(rowblock*N_diag, ho_bf1%levels(level)%Bidxe)
          vec_new = 0
 
-         n1 = OMP_get_wtime()
+         n1 = MPI_Wtime()
          do ii = idx_start_diag, idx_end_diag
 
             if (associated(ho_bf1%levels(level)%BP_inverse(ii)%LL)) then
@@ -517,7 +517,7 @@ contains
                endif
             endif
          end do
-         n2 = OMP_get_wtime()
+         n2 = MPI_Wtime()
          ! time_tmp = time_tmp + n2 - n1
 
          vec_old = vec_new
@@ -842,7 +842,9 @@ contains
 
 
 
-      use omp_lib
+#ifdef HAVE_OPENMP
+     use omp_lib
+#endif
 
       implicit none
 
@@ -890,7 +892,7 @@ contains
 
       pgno = block_o%pgno
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       ! if(block_o%level==3)then
       call BF_get_rank(block_o, ptree)
       if (level_butterfly >= option%schulzlevel) then
@@ -901,7 +903,7 @@ contains
 
       error_inout = max(error_inout, error)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       stats%Time_SMW = stats%Time_SMW + n2 - n1
       ! write(*,*)'I+B Inversion Time:',n2-n1
 
@@ -916,7 +918,9 @@ contains
 
 
 
-      use omp_lib
+#ifdef HAVE_OPENMP
+     use omp_lib
+#endif
 
       implicit none
 
@@ -966,7 +970,7 @@ contains
 
       itermax = 100
       converged = 0
-      ! n1 = OMP_get_wtime()
+      ! n1 = MPI_Wtime()
       do ii = 1, itermax
 
          write (iternumber, "(I4)") ii
@@ -1018,7 +1022,7 @@ contains
          endif
 
       enddo
-      ! n2 = OMP_get_wtime()
+      ! n2 = MPI_Wtime()
 
       if (converged == 0) then
          write (*, *) 'Schulz Iteration does not converge, consider:'
@@ -1052,7 +1056,9 @@ contains
 
 
    recursive subroutine BF_bdiag_approximation_precompute(recurlevel, bidx,bdiags, option, stats, ptree, msh, pgno)
-      use omp_lib
+#ifdef HAVE_OPENMP
+     use omp_lib
+#endif
 
       implicit none
 
@@ -1105,7 +1111,9 @@ contains
 
 
    recursive subroutine BF_bdiag_approximation(recurlevel, bidx, blocks_io,bdiags, option, stats, ptree, msh, pgno)
-      use omp_lib
+#ifdef HAVE_OPENMP
+     use omp_lib
+#endif
 
       implicit none
 
@@ -1147,9 +1155,9 @@ contains
          blocks_D => partitioned_block%sons(2, 2)
 
          ! split into four smaller butterflies
-         n1 = OMP_get_wtime()
+         n1 = MPI_Wtime()
          call BF_split(blocks_io, partitioned_block, ptree, stats, msh, option,1)
-         n2 = OMP_get_wtime()
+         n2 = MPI_Wtime()
          stats%Time_split = stats%Time_split + n2 - n1
 
          if (IOwnPgrp(ptree, blocks_A%pgno)) then
@@ -1176,7 +1184,9 @@ contains
 
 
    subroutine BF_compute_schulz_init(schulz_op, option, ptree, stats, msh)
-      use omp_lib
+#ifdef HAVE_OPENMP
+     use omp_lib
+#endif
 
       implicit none
 
@@ -1275,7 +1285,9 @@ contains
 
 
 
-      use omp_lib
+#ifdef HAVE_OPENMP
+     use omp_lib
+#endif
 
       implicit none
 
@@ -1317,9 +1329,9 @@ contains
          blocks_D => partitioned_block%sons(2, 2)
 
          ! split into four smaller butterflies
-         n1 = OMP_get_wtime()
+         n1 = MPI_Wtime()
          call BF_split(blocks_io, partitioned_block, ptree, stats, msh, option)
-         n2 = OMP_get_wtime()
+         n2 = MPI_Wtime()
          stats%Time_split = stats%Time_split + n2 - n1
 
          if (IOwnPgrp(ptree, blocks_D%pgno)) then
@@ -1338,9 +1350,9 @@ contains
             ! write(*,*)'A-BDC',level_butterfly,level
             call BF_get_rank_ABCD(partitioned_block, rank0)
             if (level_butterfly == 0) then
-               ! n1 = OMP_get_wtime()
+               ! n1 = MPI_Wtime()
                call LR_A_minusBDinvC(partitioned_block, ptree, option, stats)
-               ! n2 = OMP_get_wtime()
+               ! n2 = MPI_Wtime()
                ! time_tmp1 = time_tmp1 + n2-n1
             else
                rate = option%rankrate !1.2d0
@@ -2046,7 +2058,9 @@ contains
 
 
 
-      use omp_lib
+#ifdef HAVE_OPENMP
+     use omp_lib
+#endif
 
       implicit none
       integer level_p, ADflag, iii, jjj
@@ -2142,10 +2156,10 @@ contains
                blocks%ButterflyV%inc = 1
                blocks%ButterflyV%idx = 1
             endif
-            n3 = OMP_get_wtime()
+            n3 = MPI_Wtime()
             call Redistribute1Dto1D(blocks_i_copy%ButterflyU%blocks(1)%matrix, blocks_i_copy%M_loc, blocks_i_copy%M_p, blocks_i_copy%headm, blocks_i_copy%pgno, blocks%ButterflyU%blocks(1)%matrix, blocks%M_loc, blocks%M_p, blocks%headm, blocks%pgno, kk, ptree)
             call Redistribute1Dto1D(blocks_i_copy%ButterflyV%blocks(1)%matrix, blocks_i_copy%N_loc, blocks_i_copy%N_p, blocks_i_copy%headn, blocks_i_copy%pgno, blocks%ButterflyV%blocks(1)%matrix, blocks%N_loc, blocks%N_p, blocks%headn, blocks%pgno, kk, ptree)
-            n4 = OMP_get_wtime()
+            n4 = MPI_Wtime()
             stats%Time_RedistB = stats%Time_RedistB + n4-n3
          enddo
          enddo
@@ -2167,9 +2181,9 @@ contains
                matrixtemp1 = blocks_i_copy%ButterflyU%blocks(1)%matrix
                deallocate (blocks_i_copy%ButterflyU%blocks(1)%matrix)
                allocate (matrixtemp2(M_p_sub1(1, 2), rank))
-               n3 = OMP_get_wtime()
+               n3 = MPI_Wtime()
                call Redistribute1Dto1D(matrixtemp1, blocks_i_copy%M_loc, M_p_sub, 0, pgno_sub_mine, matrixtemp2, M_p_sub1(1, 2), M_p_sub1, 0, pgno_sub_mine, rank, ptree)
-               n4 = OMP_get_wtime()
+               n4 = MPI_Wtime()
                stats%Time_RedistB = stats%Time_RedistB + n4-n3
                if (ptree%pgrp(pgno_sub_mine)%head == ptree%MyID) then
                   allocate (blocks_i_copy%ButterflyU%blocks(1)%matrix(M_p_sub1(1, 2), rank))
@@ -2192,9 +2206,9 @@ contains
                matrixtemp1 = blocks_i_copy%ButterflyV%blocks(1)%matrix
                deallocate (blocks_i_copy%ButterflyV%blocks(1)%matrix)
                allocate (matrixtemp2(N_p_sub1(1, 2), rank))
-               n3 = OMP_get_wtime()
+               n3 = MPI_Wtime()
                call Redistribute1Dto1D(matrixtemp1, blocks_i_copy%N_loc, N_p_sub, 0, pgno_sub_mine, matrixtemp2, N_p_sub1(1, 2), N_p_sub1, 0, pgno_sub_mine, rank, ptree)
-               n4 = OMP_get_wtime()
+               n4 = MPI_Wtime()
                stats%Time_RedistB = stats%Time_RedistB + n4-n3
                if (ptree%pgrp(pgno_sub_mine)%head == ptree%MyID) then
                   allocate (blocks_i_copy%ButterflyV%blocks(1)%matrix(N_p_sub1(1, 2), rank))
@@ -2280,9 +2294,9 @@ contains
                               allocate (block_c_o%ButterflyV%blocks(1))
                            endif
                            allocate (block_c_o%ButterflyV%blocks(1)%matrix(block_c_o%N_loc, rank))
-                           n3 = OMP_get_wtime()
+                           n3 = MPI_Wtime()
                            call Redistribute1Dto1D(matrixtemp1, ld, N_p_sub1, 0, pgno_sub_mine, block_c_o%ButterflyV%blocks(1)%matrix, block_c_o%N_loc, N_p_sub, 0, pgno_sub_mine, rank, ptree)
-                           n4 = OMP_get_wtime()
+                           n4 = MPI_Wtime()
                            stats%Time_RedistB = stats%Time_RedistB + n4-n3
                            deallocate (N_p_sub)
                            deallocate (N_p_sub1)
@@ -2318,9 +2332,9 @@ contains
                               allocate (block_c_o%ButterflyU%blocks(1))
                            endif
                            allocate (block_c_o%ButterflyU%blocks(1)%matrix(block_c_o%M_loc, rank))
-                           n3 = OMP_get_wtime()
+                           n3 = MPI_Wtime()
                            call Redistribute1Dto1D(matrixtemp1, ld, M_p_sub1, 0, pgno_sub_mine, block_c_o%ButterflyU%blocks(1)%matrix, block_c_o%M_loc, M_p_sub, 0, pgno_sub_mine, rank, ptree)
-                           n4 = OMP_get_wtime()
+                           n4 = MPI_Wtime()
                            stats%Time_RedistB = stats%Time_RedistB + n4-n3
                            deallocate (M_p_sub)
                            deallocate (M_p_sub1)
@@ -2405,12 +2419,12 @@ contains
          allocate (Vo2(max(1, blocks_C%M_loc), num_vect_sub))
          Vo2 = 0
 
-         n1 = OMP_get_wtime()
+         n1 = MPI_Wtime()
          ! call Redistribute1Dto1D(vin, blocks_i%N_p, 0, blocks_i%pgno, V1, blocks_A%N_p, 0, blocks_A%pgno, num_vect_sub, ptree)
          ! call Redistribute1Dto1D(vin, blocks_i%N_p, 0, blocks_i%pgno, V2, blocks_B%N_p, blocks_A%N, blocks_B%pgno, num_vect_sub, ptree)
 
          call Redistribute1Dto1D_OnetoTwo(vin, blocks_i%N_loc, blocks_i%N_p, 0, blocks_i%pgno, V1, max(1, blocks_A%N_loc),blocks_A%N_p, 0, blocks_A%pgno,V2, max(1, blocks_B%N_loc), blocks_B%N_p, blocks_A%N, blocks_B%pgno, num_vect_sub, ptree)
-         n2 = OMP_get_wtime()
+         n2 = MPI_Wtime()
          stats%Time_RedistV = stats%Time_RedistV + n2-n1
 
 
@@ -2423,12 +2437,12 @@ contains
             call BF_block_MVP_dat(blocks_D, 'N', blocks_D%M_loc, blocks_D%N_loc, num_vect_sub, V2, max(1, blocks_B%N_loc), Vo2, max(1, blocks_C%M_loc), BPACK_cone, BPACK_cone, ptree, stats)
          endif
 
-         n1 = OMP_get_wtime()
+         n1 = MPI_Wtime()
          ! call Redistribute1Dto1D(Vo1, blocks_A%M_p, 0, blocks_A%pgno, vout2, blocks_i%M_p, 0, blocks_i%pgno, num_vect_sub, ptree)
          ! call Redistribute1Dto1D(Vo2, blocks_C%M_p, blocks_A%M, blocks_C%pgno, vout2, blocks_i%M_p, 0, blocks_i%pgno, num_vect_sub, ptree)
 
          call Redistribute1Dto1D_TwotoOne(Vo1, max(1, blocks_A%M_loc), blocks_A%M_p, 0, blocks_A%pgno,Vo2, max(1, blocks_C%M_loc), blocks_C%M_p, blocks_A%M, blocks_C%pgno, vout2, blocks_i%M_loc, blocks_i%M_p, 0, blocks_i%pgno, num_vect_sub, ptree)
-         n2 = OMP_get_wtime()
+         n2 = MPI_Wtime()
          stats%Time_RedistV = stats%Time_RedistV + n2-n1
 
          if(fnorm(vout1, blocks_i%M_loc, 1)<BPACK_SafeUnderflow .and. fnorm(vout2, blocks_i%M_loc, 1)<BPACK_SafeUnderflow)then
@@ -2476,7 +2490,9 @@ contains
    subroutine Bplus_Sblock_randomized_memfree(ho_bf1, level_c, rowblock, option, stats, ptree, msh)
 
 
-      use omp_lib
+#ifdef HAVE_OPENMP
+     use omp_lib
+#endif
       implicit none
 
       integer level_c, rowblock
@@ -2566,11 +2582,11 @@ contains
 
                   blocks => ho_bf1%levels(level)%BP_inverse(ii)%LL(1)%matrices_block(1)
                   call assert(IOwnPgrp(ptree, blocks%pgno),'I do not own this pgno')
-                  n1=OMP_get_wtime()
+                  n1=MPI_Wtime()
                   call BF_extract_partial(block_o, level_butterfly_loc, ii_loc,blocks%headm,blocks%row_group, 'L', agent_block,blocks%pgno,ptree)
                   rank0 = agent_block%rankmax
                   rate = option%rankrate !1.2d0
-                  n2=OMP_get_wtime()
+                  n2=MPI_Wtime()
                   ! time_tmp = time_tmp + n2-n1
 
                   ho_bf1%ind_lv = level
@@ -2583,9 +2599,9 @@ contains
 
                   call BF_ChangePattern(agent_block, 3, 2, stats, ptree)
 
-                  n1=OMP_get_wtime()
+                  n1=MPI_Wtime()
                   call BF_copyback_partial(block_o, level_butterfly_loc, ii_loc, 'L', agent_block,blocks%pgno,ptree)
-                  n2=OMP_get_wtime()
+                  n2=MPI_Wtime()
                   ! time_tmp = time_tmp + n2-n1
 
                   call BF_delete(agent_block,1)
@@ -2634,7 +2650,9 @@ contains
 
 
 
-      use omp_lib
+#ifdef HAVE_OPENMP
+     use omp_lib
+#endif
 
 
       implicit none
@@ -2707,7 +2725,7 @@ contains
             do bb = 1, Bplus%LL(llplus)%Nbound
                block_o => Bplus%LL(llplus)%matrices_block(bb)
                if (IOwnPgrp(ptree, block_o%pgno)) then
-                  n1 = OMP_get_wtime()
+                  n1 = MPI_Wtime()
                   !!!!! partial update butterflies at level llplus from left B1 = D^-1xB
                   if (llplus /= Lplus) then
                      rank0 = block_o%rankmax
@@ -2719,18 +2737,18 @@ contains
                      stats%Flop_Factor = stats%Flop_Factor + stats%Flop_Tmp
                      error_inout = max(error_inout, error)
                   endif
-                  n2 = OMP_get_wtime()
+                  n2 = MPI_Wtime()
                   stats%Time_PartialUpdate = stats%Time_PartialUpdate + n2 - n1
 
-                  n1 = OMP_get_wtime()
+                  n1 = MPI_Wtime()
                   !!!!! invert I+B1 to be I+B2
                   level_butterfly = block_o%level_butterfly
                   call BF_inverse_partitionedinverse_IplusButter(block_o, level_butterfly, 0, option, error, stats, ptree, msh, block_o%pgno)
                   error_inout = max(error_inout, error)
-                  n2 = OMP_get_wtime()
+                  n2 = MPI_Wtime()
                   stats%Time_SMW = stats%Time_SMW + n2 - n1
 
-                  n1 = OMP_get_wtime()
+                  n1 = MPI_Wtime()
                   if (llplus /= Lplus) then
                      rank0 = block_o%rankmax
                      rate = option%rankrate !1.2d0
@@ -2741,7 +2759,7 @@ contains
                      stats%Flop_Factor = stats%Flop_Factor + stats%Flop_Tmp
                      error_inout = max(error_inout, error)
                   endif
-                  n2 = OMP_get_wtime()
+                  n2 = MPI_Wtime()
                   stats%Time_PartialUpdate = stats%Time_PartialUpdate + n2 - n1
                endif
             end do
@@ -2774,7 +2792,9 @@ contains
 
 
 
-      use omp_lib
+#ifdef HAVE_OPENMP
+     use omp_lib
+#endif
 
 
       implicit none
@@ -2820,7 +2840,7 @@ contains
             block_o => Bplus%LL(llplus)%matrices_block(bb)
             if (IOwnPgrp(ptree, block_o%pgno)) then
 
-               n1 = OMP_get_wtime()
+               n1 = MPI_Wtime()
                !!!!! partial update butterflies at level llplus from left B1 = D^-1xB
                if (llplus /= Lplus) then
 
@@ -2880,11 +2900,11 @@ contains
                   error_inout = max(error_inout, error)
 #endif
                endif
-               n2 = OMP_get_wtime()
+               n2 = MPI_Wtime()
                stats%Time_PartialUpdate = stats%Time_PartialUpdate + n2 - n1
 
 
-               n1 = OMP_get_wtime()
+               n1 = MPI_Wtime()
                if (block_o%style == 1) then
 #if 0
                   allocate (ipiv(block_o%M))
@@ -2914,10 +2934,10 @@ contains
                   endif
                   error_inout = max(error_inout, error)
                endif
-               n2 = OMP_get_wtime()
+               n2 = MPI_Wtime()
                stats%Time_SMW = stats%Time_SMW + n2 - n1
 
-               n1 = OMP_get_wtime()
+               n1 = MPI_Wtime()
                if (llplus /= Lplus) then
                   level_butterfly = block_o%level_butterfly
                   levelm = ceiling_safe(dble(level_butterfly)/2d0)
@@ -2977,7 +2997,7 @@ contains
                   error_inout = max(error_inout, error)
 #endif
                endif
-               n2 = OMP_get_wtime()
+               n2 = MPI_Wtime()
                stats%Time_PartialUpdate = stats%Time_PartialUpdate + n2 - n1
             endif
          end do

--- a/SRC/Bplus_randomized.f90
+++ b/SRC/Bplus_randomized.f90
@@ -43,7 +43,7 @@ contains
       real(kind=8)::n1, n2, n3, n4
 
 
-      n3 = OMP_get_wtime()
+      n3 = MPI_Wtime()
       ctemp1 = 1.0d0
       ctemp2 = 0.0d0
 
@@ -61,13 +61,13 @@ contains
       allocate (Vin2(nn, num_vect_sub))
       allocate (Vout1(mm, num_vect_sub))
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       ! call Redistribute1Dto1D(Vin, block_inv%N_p, 0, block_inv%pgno, Vin1, block_off1%M_p, 0, block_off1%pgno, num_vect_sub, ptree)
       ! call Redistribute1Dto1D(Vin, block_inv%N_p, 0, block_inv%pgno, Vin2, block_off1%N_p, block_off1%M, block_off1%pgno, num_vect_sub, ptree)
 
       call Redistribute1Dto1D_OnetoTwo(Vin, ldi, block_inv%N_p, 0, block_inv%pgno, Vin1, mm, block_off1%M_p, 0, block_off1%pgno,Vin2, nn, block_off1%N_p, block_off1%M, block_off1%pgno, num_vect_sub, ptree)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       stats%Time_RedistV = stats%Time_RedistV + n2 - n1
 
       if (trans == 'N') then
@@ -102,12 +102,12 @@ contains
 
 
       ! call MPI_barrier(ptree%pgrp(block_inv%pgno)%Comm,ierr)
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       ! call Redistribute1Dto1D(Vout1, block_off1%M_p, 0, block_off1%pgno, Vout, block_inv%M_p, 0, block_inv%pgno, num_vect_sub, ptree)
       ! call Redistribute1Dto1D(Vout2, block_off1%N_p, block_off1%M, block_off1%pgno, Vout, block_inv%M_p, 0, block_inv%pgno, num_vect_sub, ptree)
       call Redistribute1Dto1D_TwotoOne(Vin1, mm, block_off1%M_p, 0, block_off1%pgno, Vin2, nn, block_off1%N_p, block_off1%M, block_off1%pgno, Vout, ldo, block_inv%M_p, 0, block_inv%pgno, num_vect_sub, ptree)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       stats%Time_RedistV = stats%Time_RedistV + n2 - n1
 
       deallocate (Vin1)
@@ -115,7 +115,7 @@ contains
       deallocate (Vout1)
       ! deallocate (Vout2)
 
-      n4 = OMP_get_wtime()
+      n4 = MPI_Wtime()
       ! time_tmp = time_tmp + n4-n3
 
 
@@ -629,7 +629,7 @@ contains
 
       call GetPgno_Sub(ptree, blocks%pgno, level_butterfly, pgno_sub_mine)
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       !>********* multiply BF^C with vectors
       RandVectOut = conjg(cmplx(RandVectOut, kind=8))
       call BF_block_MVP_partial(blocks, 'N', num_vect_sub, RandVectOut, BFvec, level - 1, ptree, stats)
@@ -640,7 +640,7 @@ contains
          enddo
       enddo
       endif
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
       !>********* compute row spaces and reconstruct blocks at level level
@@ -806,7 +806,7 @@ contains
       integer index_i_loc_k, index_j_loc_k, index_ii_loc, index_jj_loc, index_ii, index_jj
 
       Flops = 0
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       ! blocks => butterfly_block_randomized(1)
       level_butterfly = blocks%level_butterfly
 
@@ -856,7 +856,7 @@ contains
          deallocate (matB)
       endif
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       stats%Time_random(5) = stats%Time_random(5) + n2 - n1
 
       stats%Flop_Tmp = stats%Flop_Tmp + flops
@@ -901,12 +901,12 @@ contains
       call GetPgno_Sub(ptree, blocks%pgno, level_butterfly, pgno_sub_mine)
 
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       level_left_start = blocks%level_half + 1    !  check here later
       if (level_left_start > 0 .and. level_left_start == level) then
-         ! n1 = OMP_get_wtime()
+         ! n1 = MPI_Wtime()
          call BF_block_MVP_partial(blocks, 'N', num_vect_sub, RandVectIn, BFvec1, level - 1, ptree, stats)
-         ! n2 = OMP_get_wtime()
+         ! n2 = MPI_Wtime()
          call BF_all2all_vec_n_ker(blocks, BFvec1%vec(level), stats, ptree, ptree%pgrp(blocks%pgno)%nproc, level - 1, 'R', 'C', 0)
          ! time_halfbuttermul = time_halfbuttermul + n2-n1
       endif
@@ -921,7 +921,7 @@ contains
          enddo
       enddo
       endif
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
 
@@ -1137,7 +1137,7 @@ contains
       level_butterfly = blocks%level_butterfly
       level_left_start = blocks%level_half + 1    !  check here later
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       if (level == level_butterfly + 1) then
          if (level == level_left_start) then
             index_ii_loc = (index_i - BFvec%vec(level_butterfly - level + 1)%idx_r)/BFvec%vec(level_butterfly - level + 1)%inc_r + 1
@@ -1234,7 +1234,7 @@ contains
          end if
       endif
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       stats%Time_random(5) = stats%Time_random(5) + n2 - n1
 
       stats%Flop_Tmp = stats%Flop_Tmp + Flops
@@ -1245,7 +1245,9 @@ contains
 
 
 
-      use omp_lib
+#ifdef HAVE_OPENMP
+     use omp_lib
+#endif
 
       implicit none
       logical,optional::uskip,vskip
@@ -1301,20 +1303,20 @@ contains
          else
 
             allocate (block_rand(1))
-            n1 = OMP_get_wtime()
+            n1 = MPI_Wtime()
             call BF_Init_randomized(level_butterfly, rank_pre_max, groupm, groupn, blocks_o, block_rand(1), msh, ptree, option, 0)
-            n2 = OMP_get_wtime()
+            n2 = MPI_Wtime()
             stats%Time_random(1) = stats%Time_random(1) + n2 - n1
-            n1 = OMP_get_wtime()
+            n1 = MPI_Wtime()
             call BF_Reconstruction_LL(block_rand(1), blocks_o, operand, blackbox_MVP_dat, operand1, option, stats, ptree, msh, 0, block_rand(1)%level_half,vskip=vskip)
-            n2 = OMP_get_wtime()
+            n2 = MPI_Wtime()
             ! time_tmp = time_tmp + n2 - n1
             call BF_Reconstruction_RR(block_rand(1), blocks_o, operand, blackbox_MVP_dat, operand1, option, stats, ptree, msh, level_butterfly + 1, block_rand(1)%level_half + 1,uskip=uskip)
 
          endif
 
          call BF_Test_Reconstruction_Error(block_rand(1), blocks_o, operand, blackbox_MVP_dat, error_inout, ptree, stats, operand1)
-         n2 = OMP_get_wtime()
+         n2 = MPI_Wtime()
 
          call BF_get_rank(block_rand(1), ptree)
          call MPI_ALLREDUCE(MPI_IN_PLACE, error_inout, 1, MPI_double_precision, MPI_MAX, ptree%pgrp(pgno_large)%Comm, ierr)
@@ -1358,7 +1360,9 @@ contains
 
 
 
-      use omp_lib
+#ifdef HAVE_OPENMP
+     use omp_lib
+#endif
 
       implicit none
 
@@ -1395,7 +1399,7 @@ contains
       integer converged,converged1,converged2,rankmax1, rankmax2
       integer pgno_large
 
-      n3 = OMP_get_wtime()
+      n3 = MPI_Wtime()
 
       if (option%less_adapt == 0 .or. level_butterfly == 0) then
          call BF_randomized_old(pgno_large, level_butterfly, rank0, rankrate, blocks_o, operand, blackbox_MVP_dat, error_inout, strings, option, stats, ptree, msh, operand1=operand1,uskip=uskip,vskip=vskip)
@@ -1405,20 +1409,20 @@ contains
          stats%Flop_Tmp = 0
 
          allocate (block_rand(1))
-         n1 = OMP_get_wtime()
+         n1 = MPI_Wtime()
          groupm = blocks_o%row_group
          groupn = blocks_o%col_group
          call BF_Init_randomized(level_butterfly, rank_pre_max, groupm, groupn, blocks_o, block_rand(1), msh, ptree, option, 0)
-         n2 = OMP_get_wtime()
+         n2 = MPI_Wtime()
          stats%Time_random(1) = stats%Time_random(1) + n2 - n1
 
          converged = 0
          do tt = 1, option%itermax
             rank_pre_max = ceiling_safe(rank0*rankrate**(tt - 1)) + 1
             block_rand(1)%dimension_rank = rank_pre_max
-            n1 = OMP_get_wtime()
+            n1 = MPI_Wtime()
             call BF_Reconstruction_LL(block_rand(1), blocks_o, operand, blackbox_MVP_dat, operand1, option, stats, ptree, msh, 0, 0,vskip=vskip)
-            n2 = OMP_get_wtime()
+            n2 = MPI_Wtime()
             ! time_tmp = time_tmp + n2 - n1
             call BF_Reconstruction_RR(block_rand(1), blocks_o, operand, blackbox_MVP_dat, operand1, option, stats, ptree, msh, level_butterfly + 1, level_butterfly + 1,uskip=uskip)
             call BF_get_rank(block_rand(1), ptree, 0)
@@ -1439,15 +1443,15 @@ contains
             stop
          endif
 
-         n1 = OMP_get_wtime()
+         n1 = MPI_Wtime()
          call BF_Reconstruction_LL(block_rand(1), blocks_o, operand, blackbox_MVP_dat, operand1, option, stats, ptree, msh, 1, block_rand(1)%level_half,vskip=vskip)
          call BF_Reconstruction_RR(block_rand(1), blocks_o, operand, blackbox_MVP_dat, operand1, option, stats, ptree, msh, level_butterfly, block_rand(1)%level_half + 1,uskip=uskip)
-         n2 = OMP_get_wtime()
+         n2 = MPI_Wtime()
          ! time_tmp = time_tmp + n2 - n1
 
-         n1 = OMP_get_wtime()
+         n1 = MPI_Wtime()
          call BF_Test_Reconstruction_Error(block_rand(1), blocks_o, operand, blackbox_MVP_dat, error_inout, ptree, stats, operand1)
-         n2 = OMP_get_wtime()
+         n2 = MPI_Wtime()
 
          call BF_get_rank(block_rand(1), ptree)
          call MPI_ALLREDUCE(MPI_IN_PLACE, error_inout, 1, MPI_double_precision, MPI_MAX, ptree%pgrp(pgno_large)%Comm, ierr)
@@ -1462,7 +1466,7 @@ contains
          deallocate (block_rand)
 
       endif
-      n4 = OMP_get_wtime()
+      n4 = MPI_Wtime()
       return
 
    end subroutine BF_randomized
@@ -1870,9 +1874,9 @@ contains
                allocate (RandVectOut(block_rand%N_loc, num_vect_sub))
                RandVectOut = 0
 
-               n1 = OMP_get_wtime()
+               n1 = MPI_Wtime()
                call BF_Randomized_Vectors_dat('L', block_rand, RandVectIn, RandVectOut, blocks_o, operand, blackbox_MVP_dat, nth_s, nth_e, num_vect_sub, level, ptree, msh, stats, operand1)
-               n2 = OMP_get_wtime()
+               n2 = MPI_Wtime()
                stats%Time_random(2) = stats%Time_random(2) + n2 - n1
                ! Time_Vector_inverse = Time_Vector_inverse + n2-n1
                norm_tol=0
@@ -1890,9 +1894,9 @@ contains
                   deallocate(vecout)
                endif
 
-               n1 = OMP_get_wtime()
+               n1 = MPI_Wtime()
                call BF_Resolving_Butterfly_LL_dat(num_vect_sub, nth_s, nth_e, Ng, level, block_rand, RandVectIn, RandVectOut, option, ptree, msh, stats, norm_tol)
-               n2 = OMP_get_wtime()
+               n2 = MPI_Wtime()
                stats%Time_random(3) = stats%Time_random(3) + n2 - n1
 
                deallocate (RandVectIn)
@@ -1986,10 +1990,10 @@ contains
                allocate (RandVectOut(block_rand%M_loc, num_vect_sub))
                RandVectOut = 0
 
-               n1 = OMP_get_wtime()
+               n1 = MPI_Wtime()
                call BF_Randomized_Vectors_dat('R', block_rand, RandVectIn, RandVectOut, blocks_o, operand, blackbox_MVP_dat, nth_s, nth_e, num_vect_sub, level, ptree, msh, stats, operand1)
 
-               n2 = OMP_get_wtime()
+               n2 = MPI_Wtime()
                stats%Time_random(2) = stats%Time_random(2) + n2 - n1
                ! Time_Vector_inverse = Time_Vector_inverse + n2-n1
 
@@ -2009,9 +2013,9 @@ contains
                endif
 
 
-               n1 = OMP_get_wtime()
+               n1 = MPI_Wtime()
                call BF_Resolving_Butterfly_RR_dat(num_vect_sub, nth_s, nth_e, Ng, level, block_rand, RandVectIn, RandVectOut, option, ptree, msh, stats, norm_tol)
-               n2 = OMP_get_wtime()
+               n2 = MPI_Wtime()
                stats%Time_random(3) = stats%Time_random(3) + n2 - n1
 
                deallocate (RandVectIn)
@@ -2071,9 +2075,9 @@ contains
          Id = 1
       endif
 
-      n1=OMP_Get_wtime()
+      n1=MPI_Wtime()
       call blackbox_MVP_dat(operand, block_o, 'N', mm, nn, num_vect, Id, nn, Vdref, mm, BPACK_cone, BPACK_czero, ptree, stats, operand1)
-      n2=OMP_get_wtime()
+      n2=MPI_Wtime()
       time_tmp = (n2-n1)/num_vect
 
       if (IOwnPgrp(ptree, block_rand%pgno)) then
@@ -2132,7 +2136,7 @@ contains
       character side, trans
       real(kind=8)::n1,n2
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       num_vect_subsub = num_vect_sub/(nth_e - nth_s + 1)
       level_butterfly = block_rand%level_butterfly
@@ -2146,10 +2150,10 @@ contains
       idx_m_e = idx_r + nr - 1
 
       call GetPgno_Sub(ptree, block_rand%pgno, level_butterfly, pgno_sub_mine)
-      ! n2 = OMP_get_wtime()
+      ! n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2-n1
 
-      ! n1 = OMP_get_wtime()
+      ! n1 = MPI_Wtime()
       RandVectIn = 0
       RandVectOut = 0
       if (side == 'L') then
@@ -2234,16 +2238,16 @@ contains
 ! #endif
 
       endif
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       time_tmp4 = time_tmp4 + n2-n1
 
 
       ! get the left multiplied vectors
       mm = blocks_o%M_loc
       nn = blocks_o%N_loc
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       call blackbox_MVP_dat(operand, blocks_o, trans, mm, nn, num_vect_sub, RandVectIn, size(RandVectIn,1), RandVectOut, size(RandVectOut,1), BPACK_cone, BPACK_czero, ptree, stats, operand1)
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       time_tmp3 = time_tmp3 + n2-n1
       return
 
@@ -2274,7 +2278,7 @@ contains
       real(kind=8)::n1,n2,n3,n4
       integer ld
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       select TYPE (partitioned_block)
 
@@ -2302,14 +2306,14 @@ contains
 
          ld = max(N,M_loc)
          allocate (Vin(ld, num_vect_sub))
-         n3 = OMP_get_wtime()
+         n3 = MPI_Wtime()
 
          call Redistribute1Dto1D_OnetoTwo(Vinin, ldi, block_o%M_p, 0, block_o%pgno, V1, mm, blocks_A%M_p, 0, blocks_A%pgno,V2,nn, blocks_D%M_p, blocks_A%M, blocks_D%pgno, num_vect_sub, ptree)
 
          ! call Redistribute1Dto1D(Vinin, block_o%M_p, 0, block_o%pgno, V1, blocks_A%M_p, 0, blocks_A%pgno, num_vect_sub, ptree)
          ! call Redistribute1Dto1D(Vinin, block_o%M_p, 0, block_o%pgno, V2, blocks_D%M_p, blocks_A%M, blocks_D%pgno, num_vect_sub, ptree)
 
-         n4 = OMP_get_wtime()
+         n4 = MPI_Wtime()
          stats%Time_RedistV = stats%Time_RedistV + n4-n3
 
          if (mm > 0) Vin(1:blocks_A%M_loc, :) = V1
@@ -2402,7 +2406,7 @@ contains
             end if
 
          endif
-         n3 = OMP_get_wtime()
+         n3 = MPI_Wtime()
 
          call Redistribute1Dto1D_TwotoOne(V1, mm, blocks_A%M_p, 0, blocks_A%pgno,V2, nn, blocks_D%M_p, blocks_A%M, blocks_D%pgno, Vin, ld, block_o%M_p, 0, block_o%pgno, num_vect_sub, ptree)
 
@@ -2411,7 +2415,7 @@ contains
 
          Voutout(1:M_loc,1:num_vect_sub) = a*(Vin(1:M_loc,1:num_vect_sub)-Vinin(1:M_loc,1:num_vect_sub)) + b*Voutout(1:M_loc,1:num_vect_sub)
 
-         n4 = OMP_get_wtime()
+         n4 = MPI_Wtime()
          stats%Time_RedistV = stats%Time_RedistV + n4-n3
          deallocate (Vin)
          deallocate (V1)
@@ -2424,7 +2428,7 @@ contains
 
       end select
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2-n1
 
    end subroutine BF_block_MVP_inverse_ABCD_dat
@@ -2452,7 +2456,7 @@ contains
       type(Hstat)::stats
       real(kind=8)::error, tmp1, tmp2, tmp3, norm1, norm2, norm3,n1,n2
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       select TYPE (partitioned_block)
 
@@ -2520,7 +2524,7 @@ contains
 
       end select
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2-n1
 
    end subroutine BF_block_MVP_inverse_A_minusBDinvC_dat
@@ -2547,7 +2551,7 @@ contains
       select TYPE (ho_bf1)
 
       type is (hobf)
-         n3 = OMP_get_wtime()
+         n3 = MPI_Wtime()
 
          block_off1 => ho_bf1%levels(ho_bf1%ind_lv)%BP_inverse_update(ho_bf1%ind_bk*2 - 1)%LL(1)%matrices_block(1)
          block_off2 => ho_bf1%levels(ho_bf1%ind_lv)%BP_inverse_update(ho_bf1%ind_bk*2)%LL(1)%matrices_block(1)
@@ -2614,7 +2618,7 @@ contains
          ! Vout(1:mv,1:nv) = a*Vout(1:mv,1:nv) + b*Vout_tmp
          ! deallocate (Vout_tmp)
 
-         n4 = OMP_get_wtime()
+         n4 = MPI_Wtime()
          ! time_tmp = time_tmp + n4 - n3
 
 
@@ -2892,7 +2896,7 @@ contains
          select TYPE (ho_bf1)
          type is (hobf)
 
-            n3 = OMP_get_wtime()
+            n3 = MPI_Wtime()
 
             level_c = ho_bf1%ind_lv
             rowblock = ho_bf1%ind_bk
@@ -2926,9 +2930,9 @@ contains
                pp = ptree%myid - ptree%pgrp(block_o%pgno)%head + 1
                idx_start_glo = block_o%headm + block_o%M_p(pp, 1) - 1
 
-               n1 = OMP_get_wtime()
+               n1 = MPI_Wtime()
                call BF_block_MVP_dat(block_o, 'N', mm, nn, num_vect_sub, Vin, ldi ,Vbuff, mm, BPACK_cone, BPACK_czero, ptree, stats)
-               n2 = OMP_get_wtime()
+               n2 = MPI_Wtime()
                ! time_tmp = time_tmp + n2 - n1
                mm = block_o%M_loc
                allocate (vec_new(mm, num_vect_sub))
@@ -2939,7 +2943,7 @@ contains
                   idx_start_diag = max((rowblock - 1)*N_diag + 1, ho_bf1%levels(level)%Bidxs)
                   idx_end_diag = min(rowblock*N_diag, ho_bf1%levels(level)%Bidxe)
 
-                  n1 = OMP_get_wtime()
+                  n1 = MPI_Wtime()
                   do ii = idx_start_diag, idx_end_diag
                      if (associated(ho_bf1%levels(level)%BP_inverse(ii)%LL)) then
                         blocks => ho_bf1%levels(level)%BP_inverse(ii)%LL(1)%matrices_block(1)
@@ -2970,7 +2974,7 @@ contains
                         endif
                      endif
                   end do
-                  n2 = OMP_get_wtime()
+                  n2 = MPI_Wtime()
                   ! time_tmp = time_tmp + n2 - n1
 
                   ! Vbuff = vec_new
@@ -3010,7 +3014,7 @@ contains
                   idx_end_diag = min(rowblock*N_diag, ho_bf1%levels(level)%Bidxe)
 
 
-                  n1 = OMP_get_wtime()
+                  n1 = MPI_Wtime()
                   do ii = idx_start_diag, idx_end_diag
                      if (associated(ho_bf1%levels(level)%BP_inverse(ii)%LL)) then
                         blocks => ho_bf1%levels(level)%BP_inverse(ii)%LL(1)%matrices_block(1)
@@ -3041,7 +3045,7 @@ contains
                         endif
                      endif
                   end do
-                  n2 = OMP_get_wtime()
+                  n2 = MPI_Wtime()
                   ! time_tmp = time_tmp + n2 - n1
 
                   ! Vbuff = vec_new
@@ -3053,13 +3057,13 @@ contains
 
                mm = block_o%M_loc
                nn = block_o%N_loc
-               n1 = OMP_get_wtime()
+               n1 = MPI_Wtime()
                if(Vbufflag==1)then
                call BF_block_MVP_dat(block_o, 'T', mm, nn, num_vect_sub, Vbuff, mm, Vout, ldo, a, b, ptree, stats)
                else
                call BF_block_MVP_dat(block_o, 'T', mm, nn, num_vect_sub, vec_new, mm, Vout, ldo, a, b, ptree, stats)
                endif
-               n2 = OMP_get_wtime()
+               n2 = MPI_Wtime()
                ! time_tmp = time_tmp + n2 - n1
 
                deallocate (vec_new)
@@ -3070,7 +3074,7 @@ contains
             ! Vout(1:mv,1:nv) = a*Vout(1:mv,1:nv) + b*Vout_tmp
             ! deallocate (Vout_tmp)
 
-            n4 = OMP_get_wtime()
+            n4 = MPI_Wtime()
             ! time_tmp = time_tmp + n4 - n3
 
          class default
@@ -3132,7 +3136,7 @@ contains
       type is (mesh)
          select TYPE (ho_bf1)
          type is (hobf)
-            n3 = OMP_get_wtime()
+            n3 = MPI_Wtime()
 
             level_c = ho_bf1%ind_lv
             rowblock = ho_bf1%ind_bk
@@ -3164,12 +3168,12 @@ contains
                pp = ptree%myid - ptree%pgrp(block_o%pgno)%head + 1
                idx_start_glo = block_o%headm + block_o%M_p(pp, 1) - 1
 
-               n1 = OMP_get_wtime()
+               n1 = MPI_Wtime()
                call BF_block_MVP_dat(block_o, 'N', mm, nn, num_vect_sub, Vin, ldi, Vbuff, mm, BPACK_cone, BPACK_czero, ptree, stats)
-               n2 = OMP_get_wtime()
+               n2 = MPI_Wtime()
                ! time_tmp = time_tmp + n2 - n1
                mm = block_o%M_loc
-               n1 = OMP_get_wtime()
+               n1 = MPI_Wtime()
                if (associated(ho_bf1%levels(level_c)%BP_inverse(rowblock)%LL)) then
                   blocks => ho_bf1%levels(level_c)%BP_inverse(rowblock)%LL(1)%matrices_block(1)
                   qq = ptree%myid - ptree%pgrp(blocks%pgno)%head + 1
@@ -3179,7 +3183,7 @@ contains
                   idx_end_loc = tail - idx_start_glo + 1
                   call BF_block_MVP_inverse_dat(ho_bf1, level_c, rowblock, 'N', idx_end_loc - idx_start_loc + 1, num_vect_sub, Vbuff(idx_start_loc, 1), mm, Vout(idx_start_loc, 1), ldo, ptree, stats)
                endif
-               n2 = OMP_get_wtime()
+               n2 = MPI_Wtime()
                ! time_tmp = time_tmp + n2 - n1
                deallocate (Vbuff)
                Vout(1:mv,1:nv) = a*Vout(1:mv,1:nv) + b*Vout_tmp
@@ -3195,7 +3199,7 @@ contains
                ! get the left multiplied vectors
                pp = ptree%myid - ptree%pgrp(block_o%pgno)%head + 1
                idx_start_glo = block_o%headm + block_o%M_p(pp, 1) - 1
-               n1 = OMP_get_wtime()
+               n1 = MPI_Wtime()
                if (associated(ho_bf1%levels(level_c)%BP_inverse(rowblock)%LL)) then
                   blocks => ho_bf1%levels(level_c)%BP_inverse(rowblock)%LL(1)%matrices_block(1)
                   qq = ptree%myid - ptree%pgrp(blocks%pgno)%head + 1
@@ -3205,20 +3209,20 @@ contains
                   idx_end_loc = tail - idx_start_glo + 1
                   call BF_block_MVP_inverse_dat(ho_bf1, level_c, rowblock, 'T', idx_end_loc - idx_start_loc + 1, num_vect_sub, Vin(idx_start_loc, 1), ldi, Vbuff(idx_start_loc, 1),mm, ptree, stats)
                endif
-               n2 = OMP_get_wtime()
+               n2 = MPI_Wtime()
 
                ! time_tmp = time_tmp + n2 - n1
                mm = block_o%M_loc
                nn = block_o%N_loc
-               n1 = OMP_get_wtime()
+               n1 = MPI_Wtime()
                call BF_block_MVP_dat(block_o, 'T', mm, nn, num_vect_sub, Vbuff, mm, Vout, ldo, a, b, ptree, stats)
-               n2 = OMP_get_wtime()
+               n2 = MPI_Wtime()
                ! time_tmp = time_tmp + n2 - n1
                deallocate (Vbuff)
             end if
 
 
-            n4 = OMP_get_wtime()
+            n4 = MPI_Wtime()
             ! time_tmp = time_tmp + n4 - n3
          class default
             write (*, *) "unexpected type"
@@ -3813,7 +3817,7 @@ contains
                idx_end_diag = min(rowblock*N_diag, ho_bf1%levels(level)%Bidxe)
                vec_new = 0
 
-               n1 = OMP_get_wtime()
+               n1 = MPI_Wtime()
                do ii = idx_start_diag, idx_end_diag
                   if (associated(ho_bf1%levels(level)%BP_inverse(ii)%LL)) then
                      blocks => ho_bf1%levels(level)%BP_inverse(ii)%LL(1)%matrices_block(1)
@@ -3833,7 +3837,7 @@ contains
                      endif
                   endif
                end do
-               n2 = OMP_get_wtime()
+               n2 = MPI_Wtime()
                ! time_tmp = time_tmp + n2 - n1
 
                Vout(1:mv, 1:nv) = vec_new
@@ -3861,7 +3865,7 @@ contains
                idx_end_diag = min(rowblock*N_diag, ho_bf1%levels(level)%Bidxe)
                vec_new = 0
 
-               n1 = OMP_get_wtime()
+               n1 = MPI_Wtime()
                do ii = idx_start_diag, idx_end_diag
                   if (associated(ho_bf1%levels(level)%BP_inverse(ii)%LL)) then
                      blocks => ho_bf1%levels(level)%BP_inverse(ii)%LL(1)%matrices_block(1)
@@ -3880,15 +3884,15 @@ contains
                      endif
                   endif
                end do
-               n2 = OMP_get_wtime()
+               n2 = MPI_Wtime()
                ! time_tmp = time_tmp + n2 - n1
 
                vec_old = vec_new
             end do
             deallocate (vec_new)
-            n1 = OMP_get_wtime()
+            n1 = MPI_Wtime()
             call Bplus_block_MVP_dat(bplus_o, 'T', mm, nn, num_vect_sub, vec_old, mm, Vout, ldo, ctemp1, ctemp2, ptree, stats)
-            n2 = OMP_get_wtime()
+            n2 = MPI_Wtime()
             deallocate (vec_old)
          end if
 
@@ -3988,7 +3992,7 @@ contains
       Vin_tmp = Vin(1:N,1:num_vect_sub)
 
       ! call MPI_barrier(ptree%pgrp(block_inv%pgno)%Comm,ierr)
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       allocate (Vin1(mm, num_vect_sub))
       allocate (Vin2(nn, num_vect_sub))
 
@@ -3998,7 +4002,7 @@ contains
       ! call Redistribute1Dto1D(Vin, block_inv%N_p, 0, block_inv%pgno, Vin2, block_off1%N_p, block_off1%M, block_off1%pgno, num_vect_sub, ptree)
 
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       stats%Time_RedistV = stats%Time_RedistV + n2 - n1
 
       allocate (Vout1(mm, num_vect_sub))
@@ -4052,13 +4056,13 @@ contains
          ! write(*,*)'good4'
       end if
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       ! call Redistribute1Dto1D(Vout1, block_off1%M_p, 0, block_off1%pgno, Vout, block_inv%M_p, 0, block_inv%pgno, num_vect_sub, ptree)
       ! call Redistribute1Dto1D(Vout2, block_off1%N_p, block_off1%M, block_off1%pgno, Vout, block_inv%M_p, 0, block_inv%pgno, num_vect_sub, ptree)
 
       call Redistribute1Dto1D_TwotoOne(Vout1, mm, block_off1%M_p, 0, block_off1%pgno,Vout2, nn, block_off1%N_p, block_off1%M, block_off1%pgno, Vout, ldo, block_inv%M_p, 0, block_inv%pgno, num_vect_sub, ptree)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       stats%Time_RedistV = stats%Time_RedistV + n2 - n1
 
       Vin(1:N,1:num_vect_sub) = Vin_tmp
@@ -4145,7 +4149,7 @@ contains
       Vin2 = 0
       Vout2 = 0
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       call Redistribute1Dto1D(Vin, ldi, block_inv%N_p, 0, block_inv%pgno, Vin1, max(nin1, 1), Nin_p1, offin1, block_off1%pgno, num_vect_sub, ptree)
       call Redistribute1Dto1D(Vin, ldi, block_inv%N_p, 0, block_inv%pgno, Vin2, max(nin2, 1), Nin_p2, offin2, block_off2%pgno, num_vect_sub, ptree)
 
@@ -4156,7 +4160,7 @@ contains
 
       ! call Redistribute1Dto1D_OnetoTwo(Vout, block_inv%N_p, 0, block_inv%pgno, Vout1, Nout_p1, offout1, block_off1%pgno,Vout2, Nout_p2, offout2, block_off2%pgno, num_vect_sub, ptree)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       stats%Time_RedistV = stats%Time_RedistV + n2 - n1
 
       if (mm1 > 0) then
@@ -4166,13 +4170,13 @@ contains
          call Bplus_block_MVP_dat(bplus_off2, trans, mm2, nn2, num_vect_sub, Vin2, max(nin2, 1), Vout2, max(nout2, 1), a, b, ptree, stats)
       endif
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       call Redistribute1Dto1D(Vout1, max(nout1, 1), Nout_p1, offout1, block_off1%pgno, Vout, ldo, block_inv%N_p, 0, block_inv%pgno, num_vect_sub, ptree)
       call Redistribute1Dto1D(Vout2, max(nout2, 1), Nout_p2, offout2, block_off2%pgno, Vout, ldo,  block_inv%N_p, 0, block_inv%pgno, num_vect_sub, ptree)
 
       ! call Redistribute1Dto1D_TwotoOne(Vout1, Nout_p1, offout1, block_off1%pgno, Vout2, Nout_p2, offout2, block_off2%pgno, Vout, block_inv%N_p, 0, block_inv%pgno, num_vect_sub, ptree)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       stats%Time_RedistV = stats%Time_RedistV + n2 - n1
 
       deallocate (Vin1)
@@ -4255,7 +4259,7 @@ contains
          allocate (Vout2(nout2, num_vect_sub))
       endif
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       call Redistribute1Dto1D(Vin, ldi, block_inv%N_p, 0, block_inv%pgno, Vin1, nin1, Nin_p1, offin1, block_rand(ii*2 - 1 - Bidxs + 1)%pgno, num_vect_sub, ptree)
       call Redistribute1Dto1D(Vin, ldi, block_inv%N_p, 0, block_inv%pgno, Vin2, nin2, Nin_p2, offin2, block_rand(ii*2 - Bidxs + 1)%pgno, num_vect_sub, ptree)
       ! call Redistribute1Dto1D_OnetoTwo(Vin, block_inv%N_p, 0, block_inv%pgno, Vin1, Nin_p1, offin1, block_rand(ii*2 - 1 - Bidxs + 1)%pgno, Vin2, Nin_p2, offin2, block_rand(ii*2 - Bidxs + 1)%pgno, num_vect_sub, ptree)
@@ -4264,7 +4268,7 @@ contains
       call Redistribute1Dto1D(Vout, ldo, block_inv%N_p, 0, block_inv%pgno, Vout2, nout2, Nout_p2, offout2, block_rand(ii*2 - Bidxs + 1)%pgno, num_vect_sub, ptree)
       ! call Redistribute1Dto1D_OnetoTwo(Vout, block_inv%N_p, 0, block_inv%pgno, Vout1, Nout_p1, offout1, block_rand(ii*2 - 1 - Bidxs + 1)%pgno, Vout2, Nout_p2, offout2, block_rand(ii*2 - Bidxs + 1)%pgno, num_vect_sub, ptree)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       stats%Time_RedistV = stats%Time_RedistV + n2 - n1
 
       if (mm1 > 0) then
@@ -4274,13 +4278,13 @@ contains
          call BF_block_MVP_dat(block_rand(ii*2 - Bidxs + 1), trans, mm2, nn2, num_vect_sub, Vin2, nin2, Vout2, nout2, a, b, ptree, stats)
       endif
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       call Redistribute1Dto1D(Vout1, nout1, Nout_p1, offout1, block_rand(ii*2 - 1 - Bidxs + 1)%pgno, Vout, ldo, block_inv%N_p, 0, block_inv%pgno, num_vect_sub, ptree)
       call Redistribute1Dto1D(Vout2, nout2, Nout_p2, offout2, block_rand(ii*2 - Bidxs + 1)%pgno, Vout, ldo, block_inv%N_p, 0, block_inv%pgno, num_vect_sub, ptree)
       ! call Redistribute1Dto1D_TwotoOne(Vout1, Nout_p1, offout1, block_rand(ii*2 - 1 - Bidxs + 1)%pgno, Vout2, Nout_p2, offout2, block_rand(ii*2 - Bidxs + 1)%pgno, Vout, block_inv%N_p, 0, block_inv%pgno, num_vect_sub, ptree)
 
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       stats%Time_RedistV = stats%Time_RedistV + n2 - n1
 
       if (mm1 > 0) then
@@ -4653,7 +4657,7 @@ contains
       type(Hstat)::stats
       real(kind=8)::n2, n1
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       call assert(present(msh), 'operand1 cannot be skipped')
       select TYPE (msh)
@@ -4746,7 +4750,7 @@ contains
          end select
       end select
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       time_tmp3 = time_tmp3 + n2-n1
 
    end subroutine Bplus_block_MVP_diagBinvBHSS_dat
@@ -5111,7 +5115,7 @@ contains
       type(Hstat)::stats
       real(kind=8)::n2, n1
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       call assert(present(msh), 'operand1 cannot be skipped')
       select TYPE (msh)
@@ -5210,7 +5214,7 @@ contains
          end select
       end select
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       time_tmp3 = time_tmp3 + n2-n1
 
    end subroutine Bplus_block_MVP_BdiagBinvHSS_dat
@@ -5372,7 +5376,7 @@ contains
       call Bplus_Init_FromInput(bplus_o, Bplus_randomized, msh, ptree, option)
 
       ! write(*,*)'hhhhh1',Bplus_randomized%LL(1)%matrices_block(1)%level
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       rankthusfar = 0
       do bb = 1, Bplus_randomized%LL(2)%Nbound
@@ -5392,7 +5396,7 @@ contains
 
       end do
       ! call Test_Error_RR_Inner_Exact(bplus_o)
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       stats%Time_random(4) = stats%Time_random(4) + n2 - n1
 
       ! level_c = ho_bf1%ind_lv

--- a/SRC/Bplus_utilities.f90
+++ b/SRC/Bplus_utilities.f90
@@ -303,7 +303,7 @@ contains
          do bb = 1, bplus%LL(ll)%Nbound
             blocks => bplus%LL(ll)%matrices_block(bb)
 
-            n1 = OMP_get_wtime()
+            n1 = MPI_Wtime()
             if (chara == 'N') then
                if (blocks%M_loc > 0) allocate (Vout_loc(blocks%M_loc, Nrnd))
                if (blocks%N_loc > 0) allocate (Vin_loc(blocks%N_loc, Nrnd))
@@ -315,7 +315,7 @@ contains
                call Redistribute1Dto1D(random1, ldi, blocks_1%M_p, blocks_1%headm, blocks_1%pgno, Vin_loc, blocks%M_loc, blocks%M_p, blocks%headm, blocks%pgno, Nrnd, ptree)
                call Redistribute1Dto1D(Vout, N, blocks_1%N_p, blocks_1%headn, blocks_1%pgno, Vout_loc, blocks%N_loc, blocks%N_p, blocks%headn, blocks%pgno, Nrnd, ptree)
             endif
-            n2 = OMP_get_wtime()
+            n2 = MPI_Wtime()
             stats%Time_RedistV = stats%Time_RedistV + n2-n1
 
             if (blocks%N_loc > 0 .or. blocks%M_loc > 0) then
@@ -323,7 +323,7 @@ contains
                &Vin_loc, size(Vin_loc,1), Vout_loc, size(Vout_loc,1), ctemp1, ctemp2, ptree, stats)
             endif
 
-            n1 = OMP_get_wtime()
+            n1 = MPI_Wtime()
             if (chara == 'N') then
                call Redistribute1Dto1D(Vout_loc, blocks%M_loc, blocks%M_p, blocks%headm, blocks%pgno, Vout, M, blocks_1%M_p, blocks_1%headm, blocks_1%pgno, Nrnd, ptree)
                if (blocks%M_loc > 0) deallocate (Vout_loc)
@@ -333,7 +333,7 @@ contains
                if (blocks%N_loc > 0) deallocate (Vout_loc)
                if (blocks%M_loc > 0) deallocate (Vin_loc)
             endif
-            n2 = OMP_get_wtime()
+            n2 = MPI_Wtime()
             stats%Time_RedistV = stats%Time_RedistV + n2-n1
 
          end do
@@ -396,7 +396,7 @@ contains
       dat_old => null()
 
       ! call MPI_barrier(ptree%pgrp(pgno_new)%Comm,ierr)
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       if (blocks%level_butterfly == 0) then
 
@@ -502,7 +502,7 @@ contains
          endif
       endif
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       stats%Time_RedistB = stats%Time_RedistB + n2 - n1
 
    end subroutine BF_ReDistribute_Inplace
@@ -521,7 +521,7 @@ contains
       type(Hstat)::stats
 
       ! call MPI_barrier(ptree%pgrp(pgno_new)%Comm,ierr)
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       if (blocks%level_butterfly > 0) then
          if (pat_i /= pat_o) then
@@ -545,7 +545,7 @@ contains
          endif
       endif
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       stats%Time_RedistB = stats%Time_RedistB + n2 - n1
 
    end subroutine BF_ChangePattern
@@ -1369,7 +1369,7 @@ contains
       integer statusm(MPI_status_size), statusn(MPI_status_size)
       ! call MPI_Barrier(ptree%pgrp(pgno)%Comm, ierr)
       ! allocate(agent_block)
-      n1=OMP_Get_wtime()
+      n1=MPI_Wtime()
       call assert(level_butterfly_loc >= 1, 'level_butterfly_loc cannot be zero')
 
       agent_block%style = block_o%style
@@ -1604,11 +1604,11 @@ contains
          enddo
       end if
 
-      ! n2=OMP_Get_wtime()
+      ! n2=MPI_Wtime()
       ! time_tmp = time_tmp+n2-n1
 
 
-      ! n1=OMP_Get_wtime()
+      ! n1=MPI_Wtime()
 
 
       !>*********** compute M_p, N_p, ms, ns, M and N
@@ -1661,7 +1661,7 @@ contains
       enddo
 
       call BF_get_rank(agent_block, ptree)
-      n2=OMP_Get_wtime()
+      n2=MPI_Wtime()
       ! time_tmp = time_tmp+n2-n1
    end subroutine BF_extract_partial
 
@@ -2228,7 +2228,7 @@ contains
 
       real(kind=8)::n1, n2
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       mode = 'R'
       modetrans = 'C'
@@ -2473,7 +2473,7 @@ contains
       deallocate (recvquant)
       deallocate (sendIDactive)
       deallocate (recvIDactive)
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
    end subroutine BF_exchange_extraction
@@ -2513,7 +2513,7 @@ contains
 
       real(kind=8)::n1, n2
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       if (mode == 'R') modetrans = 'C'
       if (mode == 'C') modetrans = 'R'
@@ -2736,7 +2736,7 @@ contains
       deallocate (recvquant)
       deallocate (sendIDactive)
       deallocate (recvIDactive)
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
    end subroutine BF_exchange_matvec
@@ -2780,7 +2780,7 @@ contains
       integer, allocatable::sendbufall2all(:), recvbufall2all(:)
       integer::dist
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       call assert(mode /= mode_new, 'only row2col or col2row is supported')
 
@@ -2975,7 +2975,7 @@ contains
       endif
 
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
    end subroutine BF_all2all_sizes
@@ -3080,7 +3080,7 @@ contains
 !       enddo
 
 
-!       n1 = OMP_get_wtime()
+!       n1 = MPI_Wtime()
 
 !       ! communicate receive buffer sizes
 !       do tt = 1, Nsendactive
@@ -3095,7 +3095,7 @@ contains
 !       if (Nrecvactive > 0) then
 !          call MPI_waitall(Nrecvactive, R_req, statusr, ierr)
 !       endif
-!       n2 = OMP_get_wtime()
+!       n2 = MPI_Wtime()
 !       ! time_tmp = time_tmp + n2 - n1
 
 !       do tt = 1, Nsendactive
@@ -3107,7 +3107,7 @@ contains
 !          allocate (recvquant(pp)%dat_i(recvquant(pp)%size, 1))
 !       enddo
 
-!       n1 = OMP_Get_wtime()
+!       n1 = MPI_Wtime()
 
 !       ! pack the send buffer in the second pass
 !       do ii = 1, sizes%nr
@@ -3173,7 +3173,7 @@ contains
 !             call MPI_waitany(Nreqr, R_req, sendid, statusr(:,1), ierr)
 !             pp = statusr(MPI_SOURCE, 1) + 1
 !          endif
-!          ! n1 = OMP_get_wtime()
+!          ! n1 = MPI_Wtime()
 !          i = 0
 !          do while (i < recvquant(pp)%size)
 !             i = i + 1
@@ -3186,7 +3186,7 @@ contains
 !             Nskel = NINT(dble(recvquant(pp)%dat_i(i, 1)))
 !             sizes%inds(ii, jj)%size = Nskel
 !          enddo
-!          ! n2 = OMP_get_wtime()
+!          ! n2 = MPI_Wtime()
 !          ! time_tmp = time_tmp + n2 - n1
 !       enddo
 !       if (Nreqs > 0) then
@@ -3204,7 +3204,7 @@ contains
 !       enddo
 !       endif
 
-!       n2 = OMP_get_wtime()
+!       n2 = MPI_Wtime()
 !       ! time_tmp = time_tmp + n2 - n1
 
 
@@ -3252,7 +3252,7 @@ contains
       DT, allocatable::sendbufall2all(:), recvbufall2all(:)
       integer::dist
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       call assert(mode /= mode_new, 'only row2col or col2row is supported')
 
@@ -3453,7 +3453,7 @@ contains
       deallocate (recvIDactive)
 
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
    end subroutine BF_all2all_extraction
@@ -3499,7 +3499,7 @@ contains
       DT, allocatable::sendbufall2all(:), recvbufall2all(:)
       integer::dist, kerflag
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       call assert(mode /= mode_new, 'only row2col or col2row is supported')
 
@@ -3748,7 +3748,7 @@ contains
          if (allocated(recvquant(pp)%dat)) deallocate (recvquant(pp)%dat)
       enddo
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
    end subroutine BF_all2all_vec_n_ker
@@ -3795,7 +3795,7 @@ contains
 !       DT, allocatable::sendbufall2all(:), recvbufall2all(:)
 !       integer::dist
 
-!       n1 = OMP_get_wtime()
+!       n1 = MPI_Wtime()
 
 !       call assert(mode /= mode_new, 'only row2col or col2row is supported')
 
@@ -3858,7 +3858,7 @@ contains
 !          enddo
 !          enddo
 !       endif
-!       n2 = OMP_get_wtime()
+!       n2 = MPI_Wtime()
 !       time_tmp = time_tmp + n2 - n1
 
 !       do tt = 1, Nsendactive
@@ -3879,7 +3879,7 @@ contains
 !          endif
 !       enddo
 
-!       n1 = OMP_get_wtime()
+!       n1 = MPI_Wtime()
 !       ! pack the send buffer in the second pass
 !       if (ptree%pgrp(pgno_sub_mine)%head == ptree%MyID) then
 !       do ii = 1, kerls%nr
@@ -3918,7 +3918,7 @@ contains
 
 !       allocate (kerls%blocks(kerls%nr, kerls%nc))
 !       endif
-!       n2 = OMP_get_wtime()
+!       n2 = MPI_Wtime()
 !       time_tmp = time_tmp + n2 - n1
 
 !       Nreqs = 0
@@ -3957,7 +3957,7 @@ contains
 !       ! copy data from buffer to target
 !       do tt = 1, Nrecvactive
 !          pp = recvIDactive(tt)
-!          n1 = OMP_get_wtime()
+!          n1 = MPI_Wtime()
 !          i = 0
 !          do while (i < recvquant(pp)%size)
 !             i = i + 1
@@ -3979,7 +3979,7 @@ contains
 !                enddo
 !             enddo
 !          enddo
-!          n2 = OMP_get_wtime()
+!          n2 = MPI_Wtime()
 !          time_tmp = time_tmp + n2 - n1
 !       enddo
 
@@ -3997,7 +3997,7 @@ contains
 !          if (allocated(recvquant(pp)%dat)) deallocate (recvquant(pp)%dat)
 !       enddo
 
-!       ! n2 = OMP_get_wtime()
+!       ! n2 = MPI_Wtime()
 !       ! time_tmp = time_tmp + n2 - n1
 
 !    end subroutine BF_all2all_vec_n_ker
@@ -4040,7 +4040,7 @@ contains
       character::mode
       integer offset_r, offset_c
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       nproc = max(ptree%pgrp(pgno_i)%nproc, ptree%pgrp(pgno_o)%nproc)
       pgno = min(pgno_i, pgno_o)
@@ -4318,7 +4318,7 @@ contains
       deallocate (sendIDactive)
       deallocate (recvIDactive)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
    end subroutine BF_all2all_ker
@@ -4378,7 +4378,7 @@ contains
 
       if(mode_i/=mode_o)then
 
-         n1 = OMP_get_wtime()
+         n1 = MPI_Wtime()
 
          nproc = ptree%pgrp(pgno)%nproc
          tag = pgno+level*10
@@ -4625,7 +4625,7 @@ contains
          deallocate (sendIDactive)
          deallocate (recvIDactive)
 
-         n2 = OMP_get_wtime()
+         n2 = MPI_Wtime()
          ! time_tmp = time_tmp + n2 - n1
       endif
    end subroutine BF_all2all_ker_pattern
@@ -4659,7 +4659,7 @@ contains
       real(kind=8)::t1, t2
       DT, allocatable::matrixtemp1(:, :), matrixtemp2(:, :)
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
 
       do iii = 1, 2
          do jjj = 1, 2
@@ -4791,7 +4791,7 @@ contains
          endif
          enddo
       enddo
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
       ! time_tmp = time_tmp + t2 - t1
    end subroutine BF_convert_to_smallBF
 
@@ -4833,7 +4833,7 @@ contains
       integer::dist
       character::mode
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       nproc = ptree%pgrp(pgno_i)%nproc
       pgno = pgno_i
@@ -5180,7 +5180,7 @@ contains
       deallocate (sendIDactive)
       deallocate (recvIDactive)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
    end subroutine BF_all2all_ker_split
@@ -5223,7 +5223,7 @@ contains
       integer::dist
       character::mode
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       nproc = max(ptree%pgrp(pgno_i)%nproc, ptree%pgrp(pgno_o)%nproc)
       pgno = min(pgno_i, pgno_o)
@@ -5487,7 +5487,7 @@ contains
       deallocate (sendIDactive)
       deallocate (recvIDactive)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
    end subroutine BF_all2all_UV
@@ -5530,7 +5530,7 @@ contains
       integer::dist
       character::mode
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
       nproc = ptree%pgrp(pgno_i)%nproc
       pgno = pgno_i
       do iii=1,2
@@ -5887,7 +5887,7 @@ contains
       deallocate (sendIDactive)
       deallocate (recvIDactive)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
    end subroutine BF_all2all_U_split
@@ -5930,7 +5930,7 @@ contains
       integer::dist
       character::mode
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       nproc = ptree%pgrp(pgno_i)%nproc
       pgno = pgno_i
@@ -6279,7 +6279,7 @@ contains
       deallocate (sendIDactive)
       deallocate (recvIDactive)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
    end subroutine BF_all2all_V_split
@@ -6338,7 +6338,7 @@ contains
 
       integer, allocatable:: arr_acc_m(:), arr_acc_n(:)
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       level_butterfly = blocks%level_butterfly
       pgno = blocks%pgno
@@ -6417,7 +6417,7 @@ contains
          end if
 
          if (chara == 'N') then
-            n5 = OMP_get_wtime()
+            n5 = MPI_Wtime()
             if (isnanMat(random1(1:N,1:1),N,1)) then
                write (*, *) 'NAN in 1 BF_block_MVP_dat'
                stop
@@ -6440,7 +6440,7 @@ contains
             BFvec%vec(0)%nc = blocks%ButterflyV%nblk_loc
 
             do level = 0, level_half
-               ! n1 = OMP_get_wtime()
+               ! n1 = MPI_Wtime()
                call GetLocalBlockRange(ptree, blocks%pgno, level, level_butterfly, idx_r, inc_r, nr, idx_c, inc_c, nc, 'R')
 
                BFvec%vec(level + 1)%idx_r = idx_r
@@ -6468,7 +6468,7 @@ contains
 
                   if (level == 0) then
                      flops = 0
-                     n3 = OMP_get_wtime()
+                     n3 = MPI_Wtime()
 #ifdef HAVE_TASKLOOP
                      !$omp taskloop default(shared) private(j,rank,nn,flop,index_j,index_j_loc_s)
 #endif
@@ -6493,7 +6493,7 @@ contains
                      !$omp end taskloop
 #endif
                      stats%Flop_Tmp = stats%Flop_Tmp + flops
-                     n4 = OMP_get_wtime()
+                     n4 = MPI_Wtime()
                      ! time_tmp = time_tmp + n4-n3
                      call GetBlockPID(ptree, blocks%pgno, level, level_butterfly, 1, idx_c, 'R', pgno_sub)
                      if (ptree%pgrp(pgno_sub)%nproc > 1) then
@@ -6507,7 +6507,7 @@ contains
                      write(*,*)'should not arrive here'
 
                   else
-                     n3 = OMP_get_wtime()
+                     n3 = MPI_Wtime()
                      flops = 0
 #ifdef HAVE_TASKLOOP
                      !$omp taskloop default(shared) private(index_ij,index_ii,index_jj,index_ii_loc,index_jj_loc,index_i_loc,index_i_loc_s,index_i_loc_k, index_j_loc,index_j_loc_s,index_j_loc_k,ij,ii,jj,kk,i,j,index_i,index_j,mm,mm1,mm2,nn,nn1,nn2,flop)
@@ -6556,7 +6556,7 @@ contains
                      !$omp end taskloop
 #endif
                      stats%Flop_Tmp = stats%Flop_Tmp + flops
-                     n4 = OMP_get_wtime()
+                     n4 = MPI_Wtime()
                      ! time_tmp = time_tmp + n4-n3
                   endif
                endif
@@ -6566,14 +6566,14 @@ contains
                   enddo
                enddo
 
-               ! n2 = OMP_get_wtime()
+               ! n2 = MPI_Wtime()
                ! time_tmp = time_tmp + n2-n1
 
                if (level_half /= level) then
                   call BF_exchange_matvec(blocks, BFvec%vec(level + 1), stats, ptree, level, 'R', 'B')
                endif
             enddo
-            n6 = OMP_get_wtime()
+            n6 = MPI_Wtime()
             time_tmp1 = time_tmp1 + n6-n5
 
             if (level_half + 1 /= 0) then
@@ -6582,7 +6582,7 @@ contains
                call BF_all2all_vec_n_ker(blocks, BFvec%vec(level_half + 1), stats, ptree, ptree%pgrp(blocks%pgno)%nproc, level_half + 1, 'R', 'C', 0)
             endif
 
-            n5 = OMP_get_wtime()
+            n5 = MPI_Wtime()
             do level = level_half + 1, level_butterfly + 1
                call GetLocalBlockRange(ptree, blocks%pgno, level, level_butterfly, idx_r0, inc_r0, nr0, idx_c0, inc_c0, nc0, 'C')
 
@@ -6649,7 +6649,7 @@ contains
                         flops = flops + flop
                         deallocate (matrixtemp)
                      else
-                     n3 = OMP_get_wtime()
+                     n3 = MPI_Wtime()
 #ifdef HAVE_TASKLOOP
                         !$omp taskloop default(shared) private(i,index_i,index_i_loc_s,rank,mm,flop)
 #endif
@@ -6674,18 +6674,18 @@ contains
 #ifdef HAVE_TASKLOOP
                         !$omp end taskloop
 #endif
-                        n4 = OMP_get_wtime()
+                        n4 = MPI_Wtime()
                         ! time_tmp = time_tmp + n4-n3
 
                      endif
                      stats%Flop_Tmp = stats%Flop_Tmp + flops
                   else
 
-                     n3 = OMP_get_wtime()
+                     n3 = MPI_Wtime()
                      flops = 0
 
                      if (nc0 > 1 .and. inc_c0 == 1) then  ! this special treatment makes sure two threads do not write to the same address simultaneously
-                        ! n1 = OMP_get_wtime()
+                        ! n1 = MPI_Wtime()
 #ifdef HAVE_TASKLOOP
                         !$omp taskloop default(shared) private(index_ij,index_ii,index_jj,index_ii_loc,index_jj_loc,index_i_loc,index_i_loc_s,index_i_loc_k, index_j_loc,index_j_loc_s,index_j_loc_k,index_j_loc0,ij,ii,jj,kk,i,j,index_i,index_j,mm,mm1,mm2,nn,nn1,nn2,flop)
 #endif
@@ -6744,7 +6744,7 @@ contains
                         !$omp end taskloop
 #endif
 
-   ! n2 = OMP_get_wtime()
+   ! n2 = MPI_Wtime()
    ! time_tmp = time_tmp + n2-n1
 
                      else
@@ -6806,7 +6806,7 @@ contains
 
                      endif
                      stats%Flop_Tmp = stats%Flop_Tmp + flops
-                     n4 = OMP_get_wtime()
+                     n4 = MPI_Wtime()
                      ! time_tmp = time_tmp + n4-n3
                   endif
                endif
@@ -6827,7 +6827,7 @@ contains
                stop
             end if
             !deallocate (BFvec%vec)
-            n6 = OMP_get_wtime()
+            n6 = MPI_Wtime()
             time_tmp1 = time_tmp1 + n6-n5
 
          elseif (chara == 'T') then
@@ -6851,7 +6851,7 @@ contains
             BFvec%vec(0)%inc_c = 1
             BFvec%vec(0)%nc = 1
 
-            n5 = OMP_get_wtime()
+            n5 = MPI_Wtime()
             do level = level_butterfly + 1, level_half + 1, -1
                call GetLocalBlockRange(ptree, blocks%pgno, level, level_butterfly, idx_r, inc_r, nr, idx_c, inc_c, nc, 'C')
 
@@ -6881,7 +6881,7 @@ contains
 
                   if (level == level_butterfly + 1) then
                      flops = 0
-                     n3 = OMP_Get_wtime()
+                     n3 = MPI_Wtime()
 #ifdef HAVE_TASKLOOP
                      !$omp taskloop default(shared) private(i,rank,mm,flop,index_i,index_i_loc_s)
 #endif
@@ -6907,7 +6907,7 @@ contains
 #ifdef HAVE_TASKLOOP
                      !$omp end taskloop
 #endif
-                     n4 = OMP_get_wtime()
+                     n4 = MPI_Wtime()
                      ! time_tmp = time_tmp + n4-n3
                      stats%Flop_Tmp = stats%Flop_Tmp + flops
 
@@ -6922,7 +6922,7 @@ contains
                   elseif (level == 0) then
                      write(*,*)'should not arrive here'
                   else
-                     n3=OMP_get_wtime()
+                     n3=MPI_Wtime()
                      flops = 0
 #ifdef HAVE_TASKLOOP
                      !$omp taskloop default(shared) private(index_ij,ii,jj,kk,ctemp,i,j,index_i,index_j,index_i_loc,index_j_loc,index_ii,index_jj,index_ii_loc,index_jj_loc,index_i_loc_s,index_j_loc_s,index_i_loc_k,index_j_loc_k,mm,mm1,mm2,nn,nn1,nn2,flop)
@@ -6971,7 +6971,7 @@ contains
                      !$omp end taskloop
 #endif
                      stats%Flop_Tmp = stats%Flop_Tmp + flops
-                     n4 = OMP_get_wtime()
+                     n4 = MPI_Wtime()
                      ! time_tmp = time_tmp + n4-n3
                   endif
                endif
@@ -6985,7 +6985,7 @@ contains
                   call BF_exchange_matvec(blocks, BFvec%vec(level_butterfly - level + 2), stats, ptree, level, 'C', 'B')
                endif
             enddo
-            n6 = OMP_get_wtime()
+            n6 = MPI_Wtime()
             time_tmp1 = time_tmp1 + n6-n5
 
             if (level_half /= level_butterfly + 1) then
@@ -6994,7 +6994,7 @@ contains
                call BF_all2all_vec_n_ker(blocks, BFvec%vec(level_butterfly - level_half + 1), stats, ptree, ptree%pgrp(blocks%pgno)%nproc, level_half, 'C', 'R', 0)
             endif
 
-            n5 = OMP_get_wtime()
+            n5 = MPI_Wtime()
             do level = level_half, 0, -1
                call GetLocalBlockRange(ptree, blocks%pgno, level, level_butterfly, idx_r0, inc_r0, nr0, idx_c0, inc_c0, nc0, 'R')
 
@@ -7046,7 +7046,7 @@ contains
                      flops = 0
 
                      call GetBlockPID(ptree, blocks%pgno, level, level_butterfly, 1, idx_c, 'R', pgno_sub)
-                     n3=OMP_get_wtime()
+                     n3=MPI_Wtime()
                      if (ptree%pgrp(pgno_sub)%nproc > 1) then
                         nn = size(blocks%ButterflyV%blocks(1)%matrix, 1)
                         rank = size(blocks%ButterflyV%blocks(1)%matrix, 2)
@@ -7090,12 +7090,12 @@ contains
 #endif
                      endif
                      stats%Flop_Tmp = stats%Flop_Tmp + flops
-                     n4 = OMP_get_wtime()
+                     n4 = MPI_Wtime()
                      ! time_tmp = time_tmp + n4-n3
                   else
 
                      flops = 0
-                     n3 = OMP_get_wtime()
+                     n3 = MPI_Wtime()
                      if (nr0 > 1 .and. inc_r0 == 1) then ! this special treatment makes sure two threads do not write to the same address simultaneously
 #ifdef HAVE_TASKLOOP
                         !$omp taskloop default(shared) private(index_ij,ii,jj,kk,ctemp,i,j,index_i,index_j,index_i_loc,index_j_loc,index_ii,index_jj,index_ii_loc,index_jj_loc,index_i_loc_s,index_j_loc_s,index_i_loc_k,index_j_loc_k,index_i_loc0,mm,mm1,mm2,nn,nn1,nn2,flop)
@@ -7213,7 +7213,7 @@ contains
                      endif
 
                      stats%Flop_Tmp = stats%Flop_Tmp + flops
-                     n4 = OMP_get_wtime()
+                     n4 = MPI_Wtime()
                      ! time_tmp = time_tmp + n4-n3
                   endif
                endif
@@ -7233,7 +7233,7 @@ contains
                write (*, *) 'NAN in 4 BF_block_MVP_dat', blocks%row_group, blocks%col_group, blocks%level, blocks%level_butterfly
                stop
             end if
-            n6 = OMP_get_wtime()
+            n6 = MPI_Wtime()
             time_tmp1 = time_tmp1 + n6-n5
          endif
 
@@ -7256,7 +7256,7 @@ contains
 
       endif
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2-n1
       time_tmp2 = time_tmp2 + n2-n1
       return
@@ -7303,7 +7303,7 @@ contains
 
       integer, allocatable:: arr_acc_m(:), arr_acc_n(:)
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       level_butterfly = blocks%level_butterfly
       pgno = blocks%pgno
@@ -7403,9 +7403,9 @@ contains
             BFvec%vec(0)%inc_c = blocks%ButterflyV%inc
             BFvec%vec(0)%nc = blocks%ButterflyV%nblk_loc
 
-            n5 = OMP_get_wtime()
+            n5 = MPI_Wtime()
             do level = 0, level_half
-               ! n1 = OMP_get_wtime()
+               ! n1 = MPI_Wtime()
                call GetLocalBlockRange(ptree, blocks%pgno, level, level_butterfly, idx_r, inc_r, nr, idx_c, inc_c, nc, 'R')
 
                BFvec%vec(level + 1)%idx_r = idx_r
@@ -7434,7 +7434,7 @@ contains
                   if (level == 0) then
                      flops = 0
 
-                     n3 = OMP_get_wtime()
+                     n3 = MPI_Wtime()
                      group_count=blocks%ButterflyV%nblk_loc
                      allocate(transa_array(group_count),transb_array(group_count),alpha_array(group_count),beta_array(group_count),group_size(group_count),m_array(group_count),n_array(group_count),k_array(group_count),lda_array(group_count), ldb_array(group_count), ldc_array(group_count),a_array(group_count),b_array(group_count), c_array(group_count))
                      transa_array='T'
@@ -7466,7 +7466,7 @@ contains
                      stats%Flop_Tmp = stats%Flop_Tmp + flops
 
                      deallocate(transa_array,transb_array,alpha_array,beta_array,group_size,m_array,n_array,k_array,lda_array,ldb_array,ldc_array,a_array,b_array,c_array)
-                     n4 = OMP_get_wtime()
+                     n4 = MPI_Wtime()
                      ! time_tmp = time_tmp + n4-n3
 
                      call GetBlockPID(ptree, blocks%pgno, level, level_butterfly, 1, idx_c, 'R', pgno_sub)
@@ -7481,7 +7481,7 @@ contains
                      write(*,*)'should not arrive here'
                   else
 
-                     n3 = OMP_get_wtime()
+                     n3 = MPI_Wtime()
                      group_count=nr*nc
                      allocate(transa_array(group_count),transb_array(group_count),alpha_array(group_count),beta_array(group_count),group_size(group_count),m_array(group_count),n_array(group_count),k_array(group_count),lda_array(group_count), ldb_array(group_count), ldc_array(group_count),a_array(group_count),b_array(group_count), c_array(group_count))
                      transa_array='N'
@@ -7530,7 +7530,7 @@ contains
                         stats%Flop_Tmp = stats%Flop_Tmp + flops
                      enddo
                      deallocate(transa_array,transb_array,alpha_array,beta_array,group_size,m_array,n_array,k_array,lda_array,ldb_array,ldc_array,a_array,b_array,c_array)
-                     n4 = OMP_get_wtime()
+                     n4 = MPI_Wtime()
                      ! time_tmp = time_tmp + n4-n3
                   endif
                endif
@@ -7540,7 +7540,7 @@ contains
                   enddo
                enddo
 
-               ! n2 = OMP_get_wtime()
+               ! n2 = MPI_Wtime()
                ! time_tmp = time_tmp + n2-n1
 
                if (level_half /= level) then
@@ -7548,7 +7548,7 @@ contains
                endif
             enddo
 
-            n6 = OMP_get_wtime()
+            n6 = MPI_Wtime()
             time_tmp1 = time_tmp1 + n6-n5
 
             if (level_half + 1 /= 0) then
@@ -7557,7 +7557,7 @@ contains
                call BF_all2all_vec_n_ker(blocks, BFvec%vec(level_half + 1), stats, ptree, ptree%pgrp(blocks%pgno)%nproc, level_half + 1, 'R', 'C', 0)
             endif
 
-            n5 = OMP_get_wtime()
+            n5 = MPI_Wtime()
             do level = level_half + 1, level_butterfly + 1
                call GetLocalBlockRange(ptree, blocks%pgno, level, level_butterfly, idx_r0, inc_r0, nr0, idx_c0, inc_c0, nc0, 'C')
 
@@ -7624,7 +7624,7 @@ contains
                      else
 
 
-                        n3 = OMP_get_wtime()
+                        n3 = MPI_Wtime()
                         group_count=nr0
                         allocate(transa_array(group_count),transb_array(group_count),alpha_array(group_count),beta_array(group_count),group_size(group_count),m_array(group_count),n_array(group_count),k_array(group_count),lda_array(group_count), ldb_array(group_count), ldc_array(group_count),a_array(group_count),b_array(group_count), c_array(group_count))
                         transa_array='N'
@@ -7658,13 +7658,13 @@ contains
                         call gemm_batch_mkl(transa_array, transb_array, m_array, n_array, k_array, alpha_array, a_array, lda_array, b_array, ldb_array, beta_array, c_array, ldc_array, group_count, group_size,flop=flops)
 
                         deallocate(transa_array,transb_array,alpha_array,beta_array,group_size,m_array,n_array,k_array,lda_array,ldb_array,ldc_array,a_array,b_array,c_array)
-                        n4 = OMP_get_wtime()
+                        n4 = MPI_Wtime()
                         ! time_tmp = time_tmp + n4-n3
 
                      endif
                      stats%Flop_Tmp = stats%Flop_Tmp + flops
                   else
-                     n3=OMP_get_wtime()
+                     n3=MPI_Wtime()
                      if (nc0 > 1 .and. inc_c0 == 1) then
                         group_count=nr0*nc0
                         allocate(transa_array(group_count),transb_array(group_count),alpha_array(group_count),beta_array(group_count),group_size(group_count),m_array(group_count),n_array(group_count),k_array(group_count),lda_array(group_count), ldb_array(group_count), ldc_array(group_count),a_array(group_count),b_array(group_count), c_array(group_count))
@@ -7806,7 +7806,7 @@ contains
                         deallocate(transa_array,transb_array,alpha_array,beta_array,group_size,m_array,n_array,k_array,lda_array,ldb_array,ldc_array,a_array,b_array,c_array)
 
                      endif
-                     n4 = OMP_get_wtime()
+                     n4 = MPI_Wtime()
                      ! time_tmp = time_tmp + n4-n3
                   endif
                endif
@@ -7828,7 +7828,7 @@ contains
             end if
             !deallocate (BFvec%vec)
 
-            n6 = OMP_get_wtime()
+            n6 = MPI_Wtime()
             time_tmp1 = time_tmp1 + n6-n5
 
 
@@ -7854,7 +7854,7 @@ contains
             BFvec%vec(0)%inc_c = 1
             BFvec%vec(0)%nc = 1
 
-            n5 = OMP_get_wtime()
+            n5 = MPI_Wtime()
             do level = level_butterfly + 1, level_half + 1, -1
                call GetLocalBlockRange(ptree, blocks%pgno, level, level_butterfly, idx_r, inc_r, nr, idx_c, inc_c, nc, 'C')
 
@@ -7883,7 +7883,7 @@ contains
                   allocate (BFvec%vec(level_butterfly - level + 2)%blocks(BFvec%vec(level_butterfly - level + 2)%nr, BFvec%vec(level_butterfly - level + 2)%nc))
 
                   if (level == level_butterfly + 1) then
-                     n3=OMP_get_wtime()
+                     n3=MPI_Wtime()
                      group_count=blocks%ButterflyU%nblk_loc
                      allocate(transa_array(group_count),transb_array(group_count),alpha_array(group_count),beta_array(group_count),group_size(group_count),m_array(group_count),n_array(group_count),k_array(group_count),lda_array(group_count), ldb_array(group_count), ldc_array(group_count),a_array(group_count),b_array(group_count), c_array(group_count))
                      transa_array='T'
@@ -7914,7 +7914,7 @@ contains
                      enddo
                      call gemm_batch_mkl(transa_array, transb_array, m_array, n_array, k_array, alpha_array, a_array, lda_array, b_array, ldb_array, beta_array, c_array, ldc_array, group_count, group_size,flop=flops)
                      stats%Flop_Tmp = stats%Flop_Tmp + flops
-                     n4 = OMP_get_wtime()
+                     n4 = MPI_Wtime()
                      ! time_tmp = time_tmp + n4-n3
                      deallocate(transa_array,transb_array,alpha_array,beta_array,group_size,m_array,n_array,k_array,lda_array,ldb_array,ldc_array,a_array,b_array,c_array)
                      call GetBlockPID(ptree, blocks%pgno, level, level_butterfly, idx_r, 1, 'C', pgno_sub)
@@ -7928,7 +7928,7 @@ contains
                   elseif (level == 0) then
                      write(*,*)'should not arrive here'
                   else
-                     n3=OMP_get_wtime()
+                     n3=MPI_Wtime()
                      group_count=nr*nc
                      allocate(transa_array(group_count),transb_array(group_count),alpha_array(group_count),beta_array(group_count),group_size(group_count),m_array(group_count),n_array(group_count),k_array(group_count),lda_array(group_count), ldb_array(group_count), ldc_array(group_count),a_array(group_count),b_array(group_count), c_array(group_count))
                      transa_array='T'
@@ -7977,7 +7977,7 @@ contains
                         stats%Flop_Tmp = stats%Flop_Tmp + flops
                      enddo
                      deallocate(transa_array,transb_array,alpha_array,beta_array,group_size,m_array,n_array,k_array,lda_array,ldb_array,ldc_array,a_array,b_array,c_array)
-                     n4 = OMP_get_wtime()
+                     n4 = MPI_Wtime()
                      ! time_tmp = time_tmp + n4-n3
                   endif
                endif
@@ -7991,7 +7991,7 @@ contains
                   call BF_exchange_matvec(blocks, BFvec%vec(level_butterfly - level + 2), stats, ptree, level, 'C', 'B')
                endif
             enddo
-            n6 = OMP_get_wtime()
+            n6 = MPI_Wtime()
             time_tmp1 = time_tmp1 + n6-n5
 
             if (level_half /= level_butterfly + 1) then
@@ -8000,7 +8000,7 @@ contains
                call BF_all2all_vec_n_ker(blocks, BFvec%vec(level_butterfly - level_half + 1), stats, ptree, ptree%pgrp(blocks%pgno)%nproc, level_half, 'C', 'R', 0)
             endif
 
-            n5 = OMP_get_wtime()
+            n5 = MPI_Wtime()
             do level = level_half, 0, -1
                call GetLocalBlockRange(ptree, blocks%pgno, level, level_butterfly, idx_r0, inc_r0, nr0, idx_c0, inc_c0, nc0, 'R')
 
@@ -8068,7 +8068,7 @@ contains
                         flops = flops + flop
                         deallocate (matrixtemp)
                      else
-                        n3=OMP_get_wtime()
+                        n3=MPI_Wtime()
                         group_count=blocks%ButterflyV%nblk_loc
                         allocate(transa_array(group_count),transb_array(group_count),alpha_array(group_count),beta_array(group_count),group_size(group_count),m_array(group_count),n_array(group_count),k_array(group_count),lda_array(group_count), ldb_array(group_count), ldc_array(group_count),a_array(group_count),b_array(group_count), c_array(group_count))
                         transa_array='N'
@@ -8098,12 +8098,12 @@ contains
                         enddo
                         call gemm_batch_mkl(transa_array, transb_array, m_array, n_array, k_array, alpha_array, a_array, lda_array, b_array, ldb_array, beta_array, c_array, ldc_array, group_count, group_size,flop=flops)
                         deallocate(transa_array,transb_array,alpha_array,beta_array,group_size,m_array,n_array,k_array,lda_array,ldb_array,ldc_array,a_array,b_array,c_array)
-                        n4 = OMP_get_wtime()
+                        n4 = MPI_Wtime()
                         ! time_tmp = time_tmp + n4-n3
                      endif
                      stats%Flop_Tmp = stats%Flop_Tmp + flops
                   else
-                     n3=OMP_get_wtime()
+                     n3=MPI_Wtime()
                      if (nr0 > 1 .and. inc_r0 == 1) then ! this special treatment makes sure two threads do not write to the same address simultaneously
                         group_count=nr0*nc0
                         allocate(transa_array(group_count),transb_array(group_count),alpha_array(group_count),beta_array(group_count),group_size(group_count),m_array(group_count),n_array(group_count),k_array(group_count),lda_array(group_count), ldb_array(group_count), ldc_array(group_count),a_array(group_count),b_array(group_count), c_array(group_count))
@@ -8238,7 +8238,7 @@ contains
                         stats%Flop_Tmp = stats%Flop_Tmp + flops
                         deallocate(transa_array,transb_array,alpha_array,beta_array,group_size,m_array,n_array,k_array,lda_array,ldb_array,ldc_array,a_array,b_array,c_array)
                      endif
-                     n4 = OMP_get_wtime()
+                     n4 = MPI_Wtime()
                      ! time_tmp = time_tmp + n4-n3
                   endif
                endif
@@ -8253,7 +8253,7 @@ contains
                   call BF_exchange_matvec(blocks, BFvec%vec(level_butterfly - level + 2), stats, ptree, level, 'C', 'R')
                endif
             enddo
-            n6 = OMP_get_wtime()
+            n6 = MPI_Wtime()
             time_tmp1 = time_tmp1 + n6-n5
 
             if (isnanMat(random2(1:N,1:1),N,1)) then
@@ -8278,7 +8278,7 @@ contains
 
       endif
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2-n1
       time_tmp2 = time_tmp2 + n2-n1
       return
@@ -8338,7 +8338,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
    integer(c_int):: transa_magma,transb_magma
    DT:: alpha_magma,beta_magma
 
-   n1 = OMP_get_wtime()
+   n1 = MPI_Wtime()
 
    call MAGMA_init()
    dev = 0
@@ -8441,9 +8441,9 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
          BFvec%vec(0)%inc_c = blocks%ButterflyV%inc
          BFvec%vec(0)%nc = blocks%ButterflyV%nblk_loc
 
-         n5 = OMP_get_wtime()
+         n5 = MPI_Wtime()
          do level = 0, level_half
-            ! n1 = OMP_get_wtime()
+            ! n1 = MPI_Wtime()
             call GetLocalBlockRange(ptree, blocks%pgno, level, level_butterfly, idx_r, inc_r, nr, idx_c, inc_c, nc, 'R')
 
             BFvec%vec(level + 1)%idx_r = idx_r
@@ -8473,7 +8473,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                   flops = 0
                   call magmaf_wtime(n7)
 
-                  n3 = OMP_get_wtime()
+                  n3 = MPI_Wtime()
                   group_count=blocks%ButterflyV%nblk_loc
                   allocate(m_array(group_count),n_array(group_count),k_array(group_count),lda_array(group_count), ldb_array(group_count), ldc_array(group_count),a_array(group_count),b_array(group_count), c_array(group_count))
                   transa_magma=MagmaTrans
@@ -8603,7 +8603,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                   info = MAGMA_free( dldb_array )
                   info = MAGMA_free( dldc_array )
 
-                  n4 = OMP_get_wtime()
+                  n4 = MPI_Wtime()
                   ! time_tmp = time_tmp + n4-n3
 
                   call GetBlockPID(ptree, blocks%pgno, level, level_butterfly, 1, idx_c, 'R', pgno_sub)
@@ -8618,7 +8618,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                   write(*,*)'should not arrive here'
                else
 
-                  n3 = OMP_get_wtime()
+                  n3 = MPI_Wtime()
                   do j=1,2
                      group_count=nr*nc
 
@@ -8806,7 +8806,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                      info = MAGMA_free( dldc_array )
 
                   enddo
-                  n4 = OMP_get_wtime()
+                  n4 = MPI_Wtime()
                   ! time_tmp = time_tmp + n4-n3
                endif
             endif
@@ -8816,7 +8816,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                enddo
             enddo
 
-            ! n2 = OMP_get_wtime()
+            ! n2 = MPI_Wtime()
             ! time_tmp = time_tmp + n2-n1
 
             if (level_half /= level) then
@@ -8824,7 +8824,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
             endif
          enddo
 
-         n6 = OMP_get_wtime()
+         n6 = MPI_Wtime()
          time_tmp1 = time_tmp1 + n6-n5
 
          if (level_half + 1 /= 0) then
@@ -8833,7 +8833,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
             call BF_all2all_vec_n_ker(blocks, BFvec%vec(level_half + 1), stats, ptree, ptree%pgrp(blocks%pgno)%nproc, level_half + 1, 'R', 'C', 0)
          endif
 
-         n5 = OMP_get_wtime()
+         n5 = MPI_Wtime()
          do level = level_half + 1, level_butterfly + 1
             call GetLocalBlockRange(ptree, blocks%pgno, level, level_butterfly, idx_r0, inc_r0, nr0, idx_c0, inc_c0, nc0, 'C')
 
@@ -8903,7 +8903,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                   else
 
                      call magmaf_wtime(n7)
-                     n3 = OMP_get_wtime()
+                     n3 = MPI_Wtime()
                      group_count=nr0
 
                      allocate(m_array(group_count),n_array(group_count),k_array(group_count),lda_array(group_count), ldb_array(group_count), ldc_array(group_count),a_array(group_count),b_array(group_count), c_array(group_count))
@@ -9046,13 +9046,13 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                      info = MAGMA_free( dldb_array )
                      info = MAGMA_free( dldc_array )
 
-                     n4 = OMP_get_wtime()
+                     n4 = MPI_Wtime()
                      ! time_tmp = time_tmp + n4-n3
 
                   endif
                   stats%Flop_Tmp = stats%Flop_Tmp + flops
                else
-                  n3=OMP_get_wtime()
+                  n3=MPI_Wtime()
                   if (nc0 > 1 .and. inc_c0 == 1) then
                      group_count=nr0*nc0
 
@@ -9532,7 +9532,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                      info = MAGMA_free( dldc_array )
 
                   endif
-                  n4 = OMP_get_wtime()
+                  n4 = MPI_Wtime()
                   ! time_tmp = time_tmp + n4-n3
                endif
             endif
@@ -9554,7 +9554,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
          end if
          !deallocate (BFvec%vec)
 
-         n6 = OMP_get_wtime()
+         n6 = MPI_Wtime()
          time_tmp1 = time_tmp1 + n6-n5
 
 
@@ -9581,7 +9581,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
          BFvec%vec(0)%inc_c = 1
          BFvec%vec(0)%nc = 1
 
-         n5 = OMP_get_wtime()
+         n5 = MPI_Wtime()
          do level = level_butterfly + 1, level_half + 1, -1
             call GetLocalBlockRange(ptree, blocks%pgno, level, level_butterfly, idx_r, inc_r, nr, idx_c, inc_c, nc, 'C')
 
@@ -9610,7 +9610,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                allocate (BFvec%vec(level_butterfly - level + 2)%blocks(BFvec%vec(level_butterfly - level + 2)%nr, BFvec%vec(level_butterfly - level + 2)%nc))
 
                if (level == level_butterfly + 1) then
-                  n3=OMP_get_wtime()
+                  n3=MPI_Wtime()
                   group_count=blocks%ButterflyU%nblk_loc
 
                   call magmaf_wtime(n7)
@@ -9753,7 +9753,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                   info = MAGMA_free( dldc_array )
 
 
-                  n4 = OMP_get_wtime()
+                  n4 = MPI_Wtime()
                   ! time_tmp = time_tmp + n4-n3
                   call GetBlockPID(ptree, blocks%pgno, level, level_butterfly, idx_r, 1, 'C', pgno_sub)
                   if (ptree%pgrp(pgno_sub)%nproc > 1) then
@@ -9766,7 +9766,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                elseif (level == 0) then
                   write(*,*)'should not arrive here'
                else
-                  n3=OMP_get_wtime()
+                  n3=MPI_Wtime()
                   group_count=nr*nc
                   do i=1,2
                      call magmaf_wtime(n7)
@@ -9942,7 +9942,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                      info = MAGMA_free( dldb_array )
                      info = MAGMA_free( dldc_array )
                   enddo
-                  n4 = OMP_get_wtime()
+                  n4 = MPI_Wtime()
                   ! time_tmp = time_tmp + n4-n3
                endif
             endif
@@ -9956,7 +9956,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                call BF_exchange_matvec(blocks, BFvec%vec(level_butterfly - level + 2), stats, ptree, level, 'C', 'B')
             endif
          enddo
-         n6 = OMP_get_wtime()
+         n6 = MPI_Wtime()
          time_tmp1 = time_tmp1 + n6-n5
 
          if (level_half /= level_butterfly + 1) then
@@ -9965,7 +9965,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
             call BF_all2all_vec_n_ker(blocks, BFvec%vec(level_butterfly - level_half + 1), stats, ptree, ptree%pgrp(blocks%pgno)%nproc, level_half, 'C', 'R', 0)
          endif
 
-         n5 = OMP_get_wtime()
+         n5 = MPI_Wtime()
          do level = level_half, 0, -1
             call GetLocalBlockRange(ptree, blocks%pgno, level, level_butterfly, idx_r0, inc_r0, nr0, idx_c0, inc_c0, nc0, 'R')
 
@@ -10034,7 +10034,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                      flops = flops + flop
                      deallocate (matrixtemp)
                   else
-                     n3=OMP_get_wtime()
+                     n3=MPI_Wtime()
                      group_count=blocks%ButterflyV%nblk_loc
                      call magmaf_wtime(n7)
                      allocate(m_array(group_count),n_array(group_count),k_array(group_count),lda_array(group_count), ldb_array(group_count), ldc_array(group_count),a_array(group_count),b_array(group_count), c_array(group_count))
@@ -10162,12 +10162,12 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                      info = MAGMA_free( dlda_array )
                      info = MAGMA_free( dldb_array )
                      info = MAGMA_free( dldc_array )
-                     n4 = OMP_get_wtime()
+                     n4 = MPI_Wtime()
                      ! time_tmp = time_tmp + n4-n3
                   endif
                   stats%Flop_Tmp = stats%Flop_Tmp + flops
                else
-                  n3=OMP_get_wtime()
+                  n3=MPI_Wtime()
                   if (nr0 > 1 .and. inc_r0 == 1) then ! this special treatment makes sure two threads do not write to the same address simultaneously
                      group_count=nr0*nc0
                      do ii = 1, 2
@@ -10596,7 +10596,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                      info = MAGMA_free( dldb_array )
                      info = MAGMA_free( dldc_array )
                   endif
-                  n4 = OMP_get_wtime()
+                  n4 = MPI_Wtime()
                   ! time_tmp = time_tmp + n4-n3
                endif
             endif
@@ -10611,7 +10611,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
                call BF_exchange_matvec(blocks, BFvec%vec(level_butterfly - level + 2), stats, ptree, level, 'C', 'R')
             endif
          enddo
-         n6 = OMP_get_wtime()
+         n6 = MPI_Wtime()
          time_tmp1 = time_tmp1 + n6-n5
 
          if (isnanMat(random2(1:N,1:1),N,1)) then
@@ -10636,7 +10636,7 @@ subroutine BF_block_MVP_dat_batch_magma(blocks, chara, M, N, Nrnd, random1, ldi,
 
    endif
 
-   n2 = OMP_get_wtime()
+   n2 = MPI_Wtime()
    ! time_tmp = time_tmp + n2-n1
    time_tmp2 = time_tmp2 + n2-n1
 
@@ -11102,16 +11102,16 @@ end subroutine BF_block_MVP_dat_batch_magma
       head = blocks%N_p(pp, 1)
       tail = blocks%N_p(pp, 2)
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
       rank = size(blocks%ButterflyU%blocks(1)%matrix, 2)
       ncol = 0
       do nn = 1, size(blocks%inters, 1)
          ncol = ncol + blocks%inters(nn)%nc
       enddo
       allocate (Vpartial(rank, ncol))
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
       call LR_all2all_extraction(blocks, inters, Vpartial, rank, ncol, stats, ptree, msh)
-      t3 = OMP_get_wtime()
+      t3 = MPI_Wtime()
 
       nr_loc = 0
       do nn = 1, size(blocks%inters, 1)
@@ -11138,7 +11138,7 @@ end subroutine BF_block_MVP_dat_batch_magma
       deallocate (Vpartial)
       deallocate (matU)
 
-      t4 = OMP_get_wtime()
+      t4 = MPI_Wtime()
       ! time_tmp = time_tmp + t3 - t2
 
    end subroutine LR_block_extraction
@@ -11186,7 +11186,7 @@ end subroutine BF_block_MVP_dat_batch_magma
       integer::dist, pgno, ncol_loc, iidx
       integer::headm, headn, nc_loc, ncmax, nrmax, head1, tail1
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       nproc = ptree%pgrp(blocks%pgno)%nproc
       tag = blocks%pgno
@@ -11299,7 +11299,7 @@ end subroutine BF_block_MVP_dat_batch_magma
          endif
       enddo
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
 
       do tt = 1, Nsendactive
          pp = sendIDactive(tt)
@@ -11340,7 +11340,7 @@ end subroutine BF_block_MVP_dat_batch_magma
       deallocate (col_idx_loc)
       deallocate (activeproc)
 
-      n3 = OMP_get_wtime()
+      n3 = MPI_Wtime()
 
       Nreqs = 0
       do tt = 1, Nsendactive
@@ -11381,7 +11381,7 @@ end subroutine BF_block_MVP_dat_batch_magma
          enddo
       enddo
 
-      n4 = OMP_get_wtime()
+      n4 = MPI_Wtime()
       if (Nreqs > 0) then
          call MPI_waitall(Nreqs, S_req, statuss, ierr)
       endif
@@ -11438,7 +11438,7 @@ end subroutine BF_block_MVP_dat_batch_magma
       real(kind=8)::n1, n2, n3, n4, n5
 
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       headm = blocks%headm
       headn = blocks%headn
@@ -11880,7 +11880,7 @@ end subroutine BF_block_MVP_dat_batch_magma
          call list_finalizer(BFvec1%vec(level)%blocks(index_i_loc_s, index_j_loc_s)%lst)
       enddo
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
 
       !>**** generate data in BFvec%vec(0)
       do nn = 1, size(BFvec%vec(0)%index, 1)
@@ -11927,14 +11927,14 @@ end subroutine BF_block_MVP_dat_batch_magma
          endif
       enddo
 
-      n3 = OMP_get_wtime()
+      n3 = MPI_Wtime()
 
       ! write(*,*)blocks%row_group,blocks%col_group,'myid',ptree%MyID,'level',level,'before all2all'
       ! all2all communication from BFvec%vec(level_half+1) to BFvec1%vec(level_half+1)
       call BF_all2all_extraction(blocks, BFvec%vec(level_half + 1), BFvec1%vec(level_half + 1), stats, ptree, level_half, 'R', 'C')
       ! write(*,*)blocks%row_group,blocks%col_group,'myid',ptree%MyID,'level',level,'after all2all'
 
-      n4 = OMP_get_wtime()
+      n4 = MPI_Wtime()
 
       !>**** multiply BF with BFvec1
       do level = level_half + 1, level_butterfly + 1
@@ -12012,7 +12012,7 @@ end subroutine BF_block_MVP_dat_batch_magma
       enddo
       deallocate (BFvec%vec)
 
-      n5 = OMP_get_wtime()
+      n5 = MPI_Wtime()
       ! time_tmp = time_tmp + n5 - n1
       ! stats%Time_Entry_BF = stats%Time_Entry_BF + n5-n2
 
@@ -12883,7 +12883,7 @@ end subroutine BF_block_extraction_multiply_oneblock_last
       type(butterfly_vec) :: BFvec
       DT, allocatable::matrixtemp(:, :), matrixtemp1(:, :), Vout_tmp(:, :)
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       level_butterfly = blocks%level_butterfly
       pgno = blocks%pgno
@@ -12916,7 +12916,7 @@ end subroutine BF_block_extraction_multiply_oneblock_last
             allocate (BFvec%vec(level_start+1:level_end))
 
             do level = level_start, min(level_half,level_end)
-               ! n1 = OMP_get_wtime()
+               ! n1 = MPI_Wtime()
                call GetLocalBlockRange(ptree, blocks%pgno, level, level_butterfly, idx_r, inc_r, nr, idx_c, inc_c, nc, 'R')
 
                if(level/=level_end)then
@@ -13037,7 +13037,7 @@ end subroutine BF_block_extraction_multiply_oneblock_last
                enddo
                endif
 
-               ! n2 = OMP_get_wtime()
+               ! n2 = MPI_Wtime()
                ! time_tmp = time_tmp + n2-n1
 
                if (level_half /= level .and. level/=level_end) then
@@ -13334,7 +13334,7 @@ end subroutine BF_block_extraction_multiply_oneblock_last
       !$omp end parallel
 #endif
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2-n1
 
       return
@@ -14355,7 +14355,7 @@ end subroutine BF_block_extraction_multiply_oneblock_last
 
       if (option%elem_extract == 0) then
 
-         t1 = OMP_get_wtime()
+         t1 = MPI_Wtime()
 
          if (option%cpp == 1) then
             call c_f_procpointer(ker%C_FuncZmn, proc1_C)
@@ -14410,7 +14410,7 @@ end subroutine BF_block_extraction_multiply_oneblock_last
             endif
          endif
 
-         t2 = OMP_get_wtime()
+         t2 = MPI_Wtime()
          stats%Time_Entry = stats%Time_Entry + t2 - t1
 
          passflag = 2
@@ -14427,7 +14427,7 @@ end subroutine BF_block_extraction_multiply_oneblock_last
 
          passflag = minval(flags)
 
-         t1 = OMP_get_wtime()
+         t1 = MPI_Wtime()
 
          if (passflag == 0) then
 
@@ -14567,7 +14567,7 @@ end subroutine BF_block_extraction_multiply_oneblock_last
             deallocate (pmaps)
 
          endif
-         t2 = OMP_get_wtime()
+         t2 = MPI_Wtime()
          stats%Time_Entry = stats%Time_Entry + t2 - t1
          deallocate (flags)
       endif
@@ -14613,7 +14613,7 @@ end subroutine BF_block_extraction_multiply_oneblock_last
       allocate(submats1(Nsub))
       allocate(new2old_sub(Nsub))
 
-      t1 = OMP_get_wtime()
+      t1 = MPI_Wtime()
 
       !!! copy submats into submats1 as submats can have zero elements in the masks
       Ninter_loc=0
@@ -14698,7 +14698,7 @@ end subroutine BF_block_extraction_multiply_oneblock_last
          endif
       enddo
 
-      t2 = OMP_get_wtime()
+      t2 = MPI_Wtime()
       stats%Time_Entry = stats%Time_Entry + t2 - t1
 
       myflag1 = myflag
@@ -14706,7 +14706,7 @@ end subroutine BF_block_extraction_multiply_oneblock_last
 
       if (option%elem_extract == 0) then
 
-         t1 = OMP_get_wtime()
+         t1 = MPI_Wtime()
 
          do nn=1,Ninter_loc
             if (option%cpp == 1) then
@@ -14762,7 +14762,7 @@ end subroutine BF_block_extraction_multiply_oneblock_last
                endif
             endif
          enddo
-         t2 = OMP_get_wtime()
+         t2 = MPI_Wtime()
          stats%Time_Entry = stats%Time_Entry + t2 - t1
 
          passflag = 2
@@ -14781,7 +14781,7 @@ end subroutine BF_block_extraction_multiply_oneblock_last
 
          passflag = minval(flags)
 
-         t1 = OMP_get_wtime()
+         t1 = MPI_Wtime()
 
          if (passflag == 0) then
 
@@ -14973,7 +14973,7 @@ end subroutine BF_block_extraction_multiply_oneblock_last
             deallocate (nrange)
 
          endif
-         t2 = OMP_get_wtime()
+         t2 = MPI_Wtime()
          stats%Time_Entry = stats%Time_Entry + t2 - t1
          deallocate (flags)
          ! write(*,*)ptree%MyID,'out'
@@ -15083,7 +15083,7 @@ end subroutine BF_block_extraction_multiply_oneblock_last
             deallocate (pmaps)
          endif
          passflag=2
-         t2 = OMP_get_wtime()
+         t2 = MPI_Wtime()
          stats%Time_Entry = stats%Time_Entry + t2 - t1
       endif
 

--- a/SRC/MISC_DenseLA.f90
+++ b/SRC/MISC_DenseLA.f90
@@ -21,7 +21,9 @@
 #include "ButterflyPACK_config.fi"
 module MISC_DenseLA
    use BPACK_DEFS
+#ifdef HAVE_OPENMP
    use omp_lib
+#endif
 
 contains
 

--- a/SRC/MISC_utilities.f90
+++ b/SRC/MISC_utilities.f90
@@ -35,7 +35,9 @@ module MISC_Utilities
 #ifdef Intel
    USE IFPORT
 #endif
+#ifdef HAVE_OPENMP
    use omp_lib
+#endif
 
 
    integer, parameter :: int64 = selected_int_kind(18)
@@ -78,7 +80,7 @@ contains
       integer ii, jj, ijind
       character trans
 
-      ! n1 = OMP_get_wtime()
+      ! n1 = MPI_Wtime()
       if (trans == 'N') then
          do ii = 1, m
          do jj = 1, n
@@ -92,7 +94,7 @@ contains
          end do
          end do
       endif
-      ! n2 = OMP_get_wtime()
+      ! n2 = MPI_Wtime()
       ! time_memcopy = time_memcopy + n2-n1
 
    end subroutine copysubmat_assumeshape
@@ -105,7 +107,7 @@ contains
       integer ii, jj, ijind
       character trans
 
-      ! n1 = OMP_get_wtime()
+      ! n1 = MPI_Wtime()
       if (trans == 'N') then
          do ii = 1, m
          do jj = 1, n
@@ -119,7 +121,7 @@ contains
          end do
          end do
       endif
-      ! n2 = OMP_get_wtime()
+      ! n2 = MPI_Wtime()
       ! time_memcopy = time_memcopy + n2-n1
 
    end subroutine copysubmat
@@ -131,7 +133,7 @@ contains
       real(kind=8)::n1, n2
       integer ii, jj, ijind
 
-      ! n1 = OMP_get_wtime()
+      ! n1 = MPI_Wtime()
 
       ! !$omp parallel do default(shared) private(ii,jj)
       do ii = 1, m
@@ -141,7 +143,7 @@ contains
       end do
       ! !$omp end parallel do
 
-      ! n2 = OMP_get_wtime()
+      ! n2 = MPI_Wtime()
       ! time_memcopy = time_memcopy + n2-n1
 
    end subroutine copymatT
@@ -448,7 +450,7 @@ contains
       allocate (norm_UVavrbynorm_Z(Navr))
       norm_UVavrbynorm_Z = 0
 
-      n1 = OMP_get_wtime()
+      n1 = MPI_Wtime()
 
       allocate (select_column(rankmax_c))
       allocate (select_row(rankmax_r))
@@ -666,7 +668,7 @@ contains
       deallocate (norm_row_R, norm_column_R)
       deallocate (norm_UVavrbynorm_Z)
 
-      n2 = OMP_get_wtime()
+      n2 = MPI_Wtime()
       ! time_tmp = time_tmp + n2 - n1
 
 


### PR DESCRIPTION
When STRUMPACK is built without OpenMP support (`STRUMPACK_USE_OPENMP=OFF`) but with ButterflyPACK (`STRUMPACK_USE_BPACK=ON`), the build can fail because ButterflyPACK is always built with OpenMP and thus there are undefined symbol linker errors. This PR adds a CMake option `enable_openmp` (default = `ON`) which allows building the library without OpenMP for pure MPI parallel programming.