### PR TITLE
CMake: Avoid hardcoded path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,7 +470,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/butterflypack.pc.in ${CMAKE_CURRENT_B
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/butterflypack.pc
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
-set(ConfigPackageLocation lib/cmake/ButterflyPACK)
+set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/ButterflyPACK)
 install(EXPORT MYBPACKTargets FILE butterflypack-targets.cmake
   NAMESPACE ButterflyPACK:: DESTINATION ${ConfigPackageLocation})
 


### PR DESCRIPTION
The current CMake pratice would suggest the installation of CMake configuration files into `${CMAKE_INSTALL_LIBDIR}/cmake/<library_name>` with the help of `GNUInstallDirs`, instead of hardcoded path, like `lib/cmake/ButterflyPACK` in the CMakeLists.txt file of the library.

Ref: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8111